### PR TITLE
LIQO home view - list of connected peers

### DIFF
--- a/__mocks__/advertisement_noStatus.json
+++ b/__mocks__/advertisement_noStatus.json
@@ -18,21 +18,6 @@
         },
         "timeToLive": "",
         "timestamp": ""
-      },
-      "status": {
-        "advertisementStatus": "ACCEPTED",
-        "foreignNetwork": {
-          "gatewayIP": "",
-          "gatewayPrivateIP": "",
-          "podCIDR": ""
-        },
-        "observedGeneration": 1,
-        "remoteRemappedPodCIDR": "",
-        "tunnelEndpointKey": {
-          "name": "",
-          "namespace": ""
-        },
-        "vkCreated": true
       }
     }
   ],

--- a/__mocks__/advertisement_notAccepted.json
+++ b/__mocks__/advertisement_notAccepted.json
@@ -20,7 +20,7 @@
         "timestamp": ""
       },
       "status": {
-        "advertisementStatus": "ACCEPTED",
+        "advertisementStatus": "",
         "foreignNetwork": {
           "gatewayIP": "",
           "gatewayPrivateIP": "",

--- a/__mocks__/advertisement_refused.json
+++ b/__mocks__/advertisement_refused.json
@@ -20,7 +20,7 @@
         "timestamp": ""
       },
       "status": {
-        "advertisementStatus": "ACCEPTED",
+        "advertisementStatus": "REFUSED",
         "foreignNetwork": {
           "gatewayIP": "",
           "gatewayPrivateIP": "",

--- a/__mocks__/crd_fetch.json
+++ b/__mocks__/crd_fetch.json
@@ -10,7 +10,7 @@
       "metadata": {
         "name": "advertisements.protocol.liqo.io",
         "selfLink": "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/advertisements.protocol.liqo.io",
-        "resourceVersion": "000000",
+        "resourceVersion": "00000",
         "annotations": {
           "controller-gen.kubebuilder.io/version": "v0.2.5"
         }
@@ -21,6 +21,9 @@
         "names": {
           "plural": "advertisements",
           "singular": "advertisement",
+          "shortNames": [
+            "adv"
+          ],
           "kind": "Advertisement",
           "listKind": "AdvertisementList"
         },
@@ -46,6 +49,7 @@
                 "type": "object",
                 "required": [
                   "clusterId",
+                  "kubeConfigRef",
                   "network",
                   "timeToLive",
                   "timestamp"
@@ -53,6 +57,186 @@
                 "properties": {
                   "clusterId": {
                     "type": "string"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "description": "Describe a container image",
+                      "type": "object",
+                      "required": [
+                        "names"
+                      ],
+                      "properties": {
+                        "names": {
+                          "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "sizeBytes": {
+                          "description": "The size of the image in bytes.",
+                          "type": "integer",
+                          "format": "int64"
+                        }
+                      }
+                    }
+                  },
+                  "kubeConfigRef": {
+                    "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                    "type": "object",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                        "type": "string"
+                      },
+                      "resourceVersion": {
+                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "limitRange": {
+                    "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
+                    "type": "object",
+                    "required": [
+                      "limits"
+                    ],
+                    "properties": {
+                      "limits": {
+                        "description": "Limits is the list of LimitRangeItem objects that are enforced.",
+                        "type": "array",
+                        "items": {
+                          "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
+                          "type": "object",
+                          "properties": {
+                            "default": {
+                              "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "defaultRequest": {
+                              "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "max": {
+                              "description": "Max usage constraints on this kind by resource name.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "maxLimitRequestRatio": {
+                              "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "min": {
+                              "description": "Min usage constraints on this kind by resource name.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type of resource that this limit applies to.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "neighbors": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "ResourceList is a set of (resource name, quantity) pairs.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
                   },
                   "network": {
                     "type": "object",
@@ -73,13 +257,98 @@
                       },
                       "supportedProtocols": {
                         "type": "array",
-                        "items": {"type":"string"}
+                        "items": {
+                          "type": "string"
+                        }
                       }
+                    }
+                  },
+                  "prices": {
+                    "description": "ResourceList is a set of (resource name, quantity) pairs.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
                     }
                   },
                   "properties": {
                     "type": "object",
-                    "additionalProperties": {"type":"string"}
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "resourceQuota": {
+                    "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
+                    "type": "object",
+                    "properties": {
+                      "hard": {
+                        "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "scopeSelector": {
+                        "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of scope selector requirements by scope of the resources.",
+                            "type": "array",
+                            "items": {
+                              "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+                              "type": "object",
+                              "required": [
+                                "operator",
+                                "scopeName"
+                              ],
+                              "properties": {
+                                "operator": {
+                                  "description": "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "scopeName": {
+                                  "description": "The name of the scope that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
+                        "type": "array",
+                        "items": {
+                          "description": "A ResourceQuotaScope defines a filter that must match each object tracked by a quota",
+                          "type": "string"
+                        }
+                      }
+                    }
                   },
                   "timeToLive": {
                     "type": "string",
@@ -96,36 +365,12 @@
                 "type": "object",
                 "required": [
                   "advertisementStatus",
-                  "foreignNetwork",
                   "tunnelEndpointKey",
                   "vkCreated"
                 ],
                 "properties": {
                   "advertisementStatus": {
                     "type": "string"
-                  },
-                  "foreignNetwork": {
-                    "type": "object",
-                    "required": [
-                      "gatewayIP",
-                      "gatewayPrivateIP",
-                      "podCIDR"
-                    ],
-                    "properties": {
-                      "gatewayIP": {
-                        "type": "string"
-                      },
-                      "gatewayPrivateIP": {
-                        "type": "string"
-                      },
-                      "podCIDR": {
-                        "type": "string"
-                      },
-                      "supportedProtocols": {
-                        "type": "array",
-                        "items": {"type":"string"}
-                      }
-                    }
                   },
                   "localRemappedPodCIDR": {
                     "type": "string"
@@ -160,9 +405,46 @@
               }
             }
           }
-        }
+        },
+        "subresources": {
+          "status": {}
+        },
+        "versions": [
+          {
+            "name": "v1",
+            "served": true,
+            "storage": true
+          }
+        ]
       },
-      "status": {}
+      "status": {
+        "conditions": [
+          {
+            "type": "NamesAccepted",
+            "status": "True",
+            "reason": "NoConflicts",
+            "message": "no conflicts found"
+          },
+          {
+            "type": "Established",
+            "status": "True",
+            "reason": "InitialNamesAccepted",
+            "message": "the initial names have been accepted"
+          }
+        ],
+        "acceptedNames": {
+          "plural": "advertisements",
+          "singular": "advertisement",
+          "shortNames": [
+            "adv"
+          ],
+          "kind": "Advertisement",
+          "listKind": "AdvertisementList"
+        },
+        "storedVersions": [
+          "v1"
+        ]
+      }
     },
     {
       "metadata": {

--- a/__mocks__/crd_fetch_long.json
+++ b/__mocks__/crd_fetch_long.json
@@ -10,7 +10,7 @@
       "metadata": {
         "name": "advertisements.protocol.liqo.io",
         "selfLink": "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/advertisements.protocol.liqo.io",
-        "resourceVersion": "000000",
+        "resourceVersion": "00000",
         "annotations": {
           "controller-gen.kubebuilder.io/version": "v0.2.5"
         }
@@ -21,6 +21,9 @@
         "names": {
           "plural": "advertisements",
           "singular": "advertisement",
+          "shortNames": [
+            "adv"
+          ],
           "kind": "Advertisement",
           "listKind": "AdvertisementList"
         },
@@ -46,6 +49,7 @@
                 "type": "object",
                 "required": [
                   "clusterId",
+                  "kubeConfigRef",
                   "network",
                   "timeToLive",
                   "timestamp"
@@ -53,6 +57,186 @@
                 "properties": {
                   "clusterId": {
                     "type": "string"
+                  },
+                  "images": {
+                    "type": "array",
+                    "items": {
+                      "description": "Describe a container image",
+                      "type": "object",
+                      "required": [
+                        "names"
+                      ],
+                      "properties": {
+                        "names": {
+                          "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "sizeBytes": {
+                          "description": "The size of the image in bytes.",
+                          "type": "integer",
+                          "format": "int64"
+                        }
+                      }
+                    }
+                  },
+                  "kubeConfigRef": {
+                    "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+                    "type": "object",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "fieldPath": {
+                        "description": "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "description": "Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                        "type": "string"
+                      },
+                      "resourceVersion": {
+                        "description": "Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "limitRange": {
+                    "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
+                    "type": "object",
+                    "required": [
+                      "limits"
+                    ],
+                    "properties": {
+                      "limits": {
+                        "description": "Limits is the list of LimitRangeItem objects that are enforced.",
+                        "type": "array",
+                        "items": {
+                          "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
+                          "type": "object",
+                          "properties": {
+                            "default": {
+                              "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "defaultRequest": {
+                              "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "max": {
+                              "description": "Max usage constraints on this kind by resource name.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "maxLimitRequestRatio": {
+                              "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "min": {
+                              "description": "Min usage constraints on this kind by resource name.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": {
+                              "description": "Type of resource that this limit applies to.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "neighbors": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "ResourceList is a set of (resource name, quantity) pairs.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
                   },
                   "network": {
                     "type": "object",
@@ -73,13 +257,98 @@
                       },
                       "supportedProtocols": {
                         "type": "array",
-                        "items": {"type":"string"}
+                        "items": {
+                          "type": "string"
+                        }
                       }
+                    }
+                  },
+                  "prices": {
+                    "description": "ResourceList is a set of (resource name, quantity) pairs.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "x-kubernetes-int-or-string": true
                     }
                   },
                   "properties": {
                     "type": "object",
-                    "additionalProperties": {"type":"string"}
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "resourceQuota": {
+                    "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
+                    "type": "object",
+                    "properties": {
+                      "hard": {
+                        "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "scopeSelector": {
+                        "description": "scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota but expressed using ScopeSelectorOperator in combination with possible values. For a resource to match, both scopes AND scopeSelector (if specified in spec), must be matched.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "A list of scope selector requirements by scope of the resources.",
+                            "type": "array",
+                            "items": {
+                              "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+                              "type": "object",
+                              "required": [
+                                "operator",
+                                "scopeName"
+                              ],
+                              "properties": {
+                                "operator": {
+                                  "description": "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "scopeName": {
+                                  "description": "The name of the scope that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "scopes": {
+                        "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects.",
+                        "type": "array",
+                        "items": {
+                          "description": "A ResourceQuotaScope defines a filter that must match each object tracked by a quota",
+                          "type": "string"
+                        }
+                      }
+                    }
                   },
                   "timeToLive": {
                     "type": "string",
@@ -96,36 +365,12 @@
                 "type": "object",
                 "required": [
                   "advertisementStatus",
-                  "foreignNetwork",
                   "tunnelEndpointKey",
                   "vkCreated"
                 ],
                 "properties": {
                   "advertisementStatus": {
                     "type": "string"
-                  },
-                  "foreignNetwork": {
-                    "type": "object",
-                    "required": [
-                      "gatewayIP",
-                      "gatewayPrivateIP",
-                      "podCIDR"
-                    ],
-                    "properties": {
-                      "gatewayIP": {
-                        "type": "string"
-                      },
-                      "gatewayPrivateIP": {
-                        "type": "string"
-                      },
-                      "podCIDR": {
-                        "type": "string"
-                      },
-                      "supportedProtocols": {
-                        "type": "array",
-                        "items": {"type":"string"}
-                      }
-                    }
                   },
                   "localRemappedPodCIDR": {
                     "type": "string"
@@ -160,9 +405,46 @@
               }
             }
           }
-        }
+        },
+        "subresources": {
+          "status": {}
+        },
+        "versions": [
+          {
+            "name": "v1",
+            "served": true,
+            "storage": true
+          }
+        ]
       },
-      "status": {}
+      "status": {
+        "conditions": [
+          {
+            "type": "NamesAccepted",
+            "status": "True",
+            "reason": "NoConflicts",
+            "message": "no conflicts found"
+          },
+          {
+            "type": "Established",
+            "status": "True",
+            "reason": "InitialNamesAccepted",
+            "message": "the initial names have been accepted"
+          }
+        ],
+        "acceptedNames": {
+          "plural": "advertisements",
+          "singular": "advertisement",
+          "shortNames": [
+            "adv"
+          ],
+          "kind": "Advertisement",
+          "listKind": "AdvertisementList"
+        },
+        "storedVersions": [
+          "v1"
+        ]
+      }
     },
     {
           "metadata": {

--- a/__mocks__/foreigncluster_noIncoming.json
+++ b/__mocks__/foreigncluster_noIncoming.json
@@ -1,0 +1,46 @@
+{
+  "apiVersion": "discovery.liqo.io/v1",
+  "items": [
+    {
+      "apiVersion": "discovery.liqo.io/v1",
+      "kind": "ForeignCluster",
+      "metadata": {
+        "labels": {
+          "cluster-id": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "discovery-type": "LAN"
+        },
+        "name": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "resourceVersion": "000000",
+        "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters/8d73c01a-f23a-45dc-822b-7d3232683f53"
+      },
+      "spec": {
+        "allowUntrustedCA": true,
+        "apiUrl": "https://1.1.1.1:1234",
+        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "discoveryType": "LAN",
+        "join": true,
+        "namespace": "liqo"
+      },
+      "status": {
+        "incoming": {
+          "joined": false
+        },
+        "outgoing": {
+          "advertisement": {
+            "apiVersion": "protocol.liqo.io/v1",
+            "kind": "Advertisement",
+            "name": "advertisement-8d73c01a-f23a-45dc-822b-7d3232683f53"
+          },
+          "joined": true,
+          "remote-peering-request-name": "4317f039-e7b8-40d2-ae20-18d1c47e69f0"
+        },
+        "ttl": 3
+      }
+    }
+  ],
+  "kind": "ForeignClusterList",
+  "metadata": {
+    "resourceVersion": "000000",
+    "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters"
+  }
+}

--- a/__mocks__/foreigncluster_noOutgoing.json
+++ b/__mocks__/foreigncluster_noOutgoing.json
@@ -1,0 +1,44 @@
+{
+  "apiVersion": "discovery.liqo.io/v1",
+  "items": [
+    {
+      "apiVersion": "discovery.liqo.io/v1",
+      "kind": "ForeignCluster",
+      "metadata": {
+        "labels": {
+          "cluster-id": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "discovery-type": "LAN"
+        },
+        "name": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "resourceVersion": "000000",
+        "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters/8d73c01a-f23a-45dc-822b-7d3232683f53"
+      },
+      "spec": {
+        "allowUntrustedCA": true,
+        "apiUrl": "https://1.1.1.1:1234",
+        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "discoveryType": "LAN",
+        "join": true,
+        "namespace": "liqo"
+      },
+      "status": {
+        "incoming": {
+          "joined": true,
+          "peeringRequest": {
+            "name": "8d73c01a-f23a-45dc-822b-7d3232683f53"
+          }
+        },
+        "outgoing": {
+          "joined": false,
+          "remote-peering-request-name": "4317f039-e7b8-40d2-ae20-18d1c47e69f0"
+        },
+        "ttl": 3
+      }
+    }
+  ],
+  "kind": "ForeignClusterList",
+  "metadata": {
+    "resourceVersion": "000000",
+    "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters"
+  }
+}

--- a/src/home/ConnectedPeer.js
+++ b/src/home/ConnectedPeer.js
@@ -1,0 +1,197 @@
+import React, { Component } from 'react';
+import {
+  Col,
+  Avatar, Collapse, Dropdown, Menu, Typography,
+  Progress, Row, Space, Tag, Tooltip, Button
+} from 'antd';
+import ToolOutlined from '@ant-design/icons/lib/icons/ToolOutlined';
+import EllipsisOutlined from '@ant-design/icons/lib/icons/EllipsisOutlined';
+import SnippetsOutlined from '@ant-design/icons/lib/icons/SnippetsOutlined';
+import AuditOutlined from '@ant-design/icons/lib/icons/AuditOutlined';
+import CloseOutlined from '@ant-design/icons/lib/icons/CloseOutlined';
+import UserOutlined from '@ant-design/icons/lib/icons/UserOutlined';
+import ClusterOutlined from '@ant-design/icons/lib/icons/ClusterOutlined';
+import SwapOutlined from '@ant-design/icons/lib/icons/SwapOutlined';
+import SwapRightOutlined from '@ant-design/icons/lib/icons/SwapRightOutlined';
+import SwapLeftOutlined from '@ant-design/icons/lib/icons/SwapLeftOutlined';
+import { getColor, updatePeeringStatus } from './HomeUtils';
+
+class ConnectedPeer extends Component {
+  constructor(props) {
+    super(props);
+
+    /**
+     * @loading: if is connecting
+     * @backgroundColor: if selected
+     */
+    this.state = {
+      loading: false,
+      backgroundColor: 'white'
+    }
+
+    this.disconnect = this.disconnect.bind(this);
+  }
+
+  clientPercentage() {
+    //TODO: retrieve client consumption percentage
+    return 50;
+  }
+
+  serverPercentage() {
+    //TODO: retrieve server consumption percentage
+    return 90;
+  }
+
+  checkSharing() {
+    //TODO: create sharing detect function
+    return true;
+  }
+
+  /** Disconnect from peer (it makes foreignCluster's spec join parameter false) */
+  disconnect() {
+    this.props.foreignCluster.spec.join = false;
+
+    updatePeeringStatus(this,
+      'Disconnected from ' + this.props.foreignCluster.metadata.name,
+      'Could not disconnect');
+  }
+
+  render(){
+
+    const menu = (
+      <Menu>
+        <Menu.Item key={'properties'} icon={<ToolOutlined />}>
+          Properties
+        </Menu.Item>
+        <Menu.Item key={'details'} icon={<SnippetsOutlined />}>
+          Details
+        </Menu.Item>
+        <Menu.Item key={'rules'} icon={<AuditOutlined />}>
+          Rules
+        </Menu.Item>
+        <Menu.Item danger key={'disconnect'} icon={<CloseOutlined />} onClick={() => {this.disconnect()}}>
+          Disconnect
+        </Menu.Item>
+      </Menu>
+    )
+
+    /** Quantity of available resources I am using on you */
+    let clientPercent = 0;
+
+    if(this.props.client)
+      clientPercent = this.clientPercentage();
+
+    /** Quantity of available resources you are using on me */
+    let serverPercent = 0;
+
+    if(this.props.server)
+      serverPercent = this.serverPercentage();
+
+    /** If there is resource sharing */
+    let sharing = this.checkSharing();
+
+    return(
+      <div style={{ paddingTop: '1em', paddingBottom: '1em' }}>
+        <Collapse accordion bordered={false}
+                  style={{backgroundColor: this.state.backgroundColor}}
+                  onChange={(collapsed) => {
+                    if(collapsed){
+                      this.setState({backgroundColor: '#e6f7ff'})
+                    } else {
+                      this.setState({backgroundColor: 'white'})
+                    }
+                  }}
+        >
+          <Collapse.Panel header={
+            <>
+              <Space size={'middle'}>
+                <div>
+                  <Tooltip title={
+                    <div>You {this.props.server ? ': ' + serverPercent + '%' : null}</div>
+                  } placement={'top'}>
+                    <Progress
+                      width={54}
+                      type="circle"
+                      percent={serverPercent}
+                      strokeWidth={10}
+                      trailColor={this.props.server ? null : this.state.backgroundColor}
+                      strokeColor={this.props.server ? getColor(serverPercent) : this.state.backgroundColor}
+                      format={() => (
+                        <Avatar
+                          size="large"
+                          style={sharing ? { backgroundColor: '#1890ff' } : { backgroundColor: '#ccc' }}
+                          icon={<UserOutlined />}
+                        />
+                      )}
+                    />
+                  </Tooltip>
+                </div>
+                {
+                  (this.props.client && this.props.server) ? <SwapOutlined style={{fontSize: '2em'}} /> :
+                  this.props.client ? <SwapRightOutlined style={{fontSize: '2em'}} /> : <SwapLeftOutlined style={{fontSize: '2em'}} />
+                }
+                <div>
+                  <Tooltip title={this.props.client ? clientPercent + '%' : null} placement={'top'}>
+                    <Progress
+                      width={54}
+                      type="circle"
+                      percent={clientPercent}
+                      strokeWidth={10}
+                      trailColor={this.props.client ? null : this.state.backgroundColor}
+                      strokeColor={this.props.client ? getColor(clientPercent) : this.state.backgroundColor}
+                      format={() => (
+                        <Avatar
+                          size="large"
+                          style={sharing ? { backgroundColor: '#1890ff' } : { backgroundColor: '#ccc' }}
+                          icon={<ClusterOutlined />}
+                        />
+                      )}
+                    />
+                  </Tooltip>
+                </div>
+                <Tooltip placement={'top'} title={this.props.foreignCluster.spec.clusterID}>
+                  <Tag style={{ maxWidth: '10vw', overflow: 'hidden', textOverflow: 'ellipsis'}}
+                       color="blue">{this.props.foreignCluster.spec.clusterID}
+                  </Tag>
+                </Tooltip>
+              </Space>
+            </>
+          }
+          extra={
+            <div aria-label={'dropdown-connected'} onClick={event => {event.stopPropagation()}}>
+              <Dropdown.Button overlay={menu} trigger={['click']} icon={<EllipsisOutlined/>}/>
+            </div>
+          }
+          showArrow={false}
+          key={this.props.foreignCluster.metadata.name + '_connected'}
+          style={{border: 0}}
+          >
+            <div style={{paddingLeft: '1em', paddingBottom: '1em'}}>
+              <Row align={'middle'}>
+                <Col flex={2}>
+                  <Typography.Text type={'secondary'}>
+                    { 'Connected on ' + this.props.foreignCluster.spec.discoveryType}
+                    { sharing ? ', sharing' : ', not sharing'}
+                  </Typography.Text>
+                </Col>
+                <Col flex={3}>
+                  <div style={{float: 'right'}}>
+                    <Button style={{marginRight: '1em'}}
+                    >
+                      Properties
+                    </Button>
+                    <Button type={'danger'} onClick={() => this.disconnect()}>
+                      Disconnect
+                    </Button>
+                  </div>
+                </Col>
+              </Row>
+            </div>
+          </Collapse.Panel>
+        </Collapse>
+      </div>
+    )
+  }
+}
+
+export default ConnectedPeer;

--- a/src/home/HomeUtils.js
+++ b/src/home/HomeUtils.js
@@ -1,0 +1,91 @@
+import { Input, Space, Button, Pagination, Progress, Table,  Alert, notification, Tabs, Tag } from 'antd';
+import { APP_NAME } from '../constants';
+import ToolOutlined from '@ant-design/icons/lib/icons/ToolOutlined';
+import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
+import FormViewer from '../editors/OAPIV3FormGenerator/FormViewer';
+import React from 'react';
+
+/** Return the right color from the percentage given */
+export function getColor(percent) {
+  if(percent < 70) {
+    return '#1890ff';
+  } else if (percent >= 70 && percent < 90) {
+    return '#faad14';
+  } else if (percent >=90) {
+    return '#f5222d';
+  }
+}
+
+/**
+ * Search an advertisement from a pool of advertisements
+ * @advertisements: the total of advertisements in the cluster
+ * @advertisement: the foreign cluster's advertisement
+ * @returns true if the advertisement exist and is ACCEPTED, false if not
+ * if false it also returns a reason why (the advertisement do not exists,
+ * the advertisement is REFUSED or is not ACCEPTED)
+ */
+export function checkAdvertisement(advertisements, advertisement) {
+  let adv = advertisements.find(adv => {return adv.metadata.name === advertisement.name});
+  if(adv){
+    if(adv.status){
+      if(adv.status.advertisementStatus === 'ACCEPTED'){
+        return {adv: true}
+      } else if(adv.status.advertisementStatus === 'REFUSED'){
+        return {adv: false, reason: 'Advertisement Refused'}
+      } else {
+        return {adv: false, reason: 'Adv. not accepted yet'}
+      }
+    } else {
+      return {adv: false, reason: 'Adv. status not defined'}
+    }
+  } else {
+    return {adv: false, reason: 'Advertisement not present'}
+  }
+}
+
+/**
+ * For now Peering Requests are always accepted, so just check
+ * if there is one
+ */
+export function checkPeeringRequest(peeringRequests, peeringRequest) {
+  let pr = peeringRequests.find(pr => {return pr.metadata.name === peeringRequest.name});
+
+  if(pr)
+    return true;
+}
+
+/** Updates the peering status: CR foreign cluster's joined true or false */
+export function updatePeeringStatus(_this, messageOK, messageError) {
+  let item = {
+    spec: _this.props.foreignCluster.spec
+  }
+
+  _this.setState({loading: true});
+
+  let foreignClusterCRD = _this.props.api.getCRDfromKind('ForeignCluster');
+
+  let promise = _this.props.api.updateCustomResource(
+    foreignClusterCRD.spec.group,
+    foreignClusterCRD.spec.version,
+    _this.props.foreignCluster.metadata.namespace,
+    foreignClusterCRD.spec.names.plural,
+    _this.props.foreignCluster.metadata.name,
+    item
+  );
+
+  promise
+    .then(() => {
+      notification.success({
+        message: APP_NAME,
+        description: messageOK
+      });
+    })
+    .catch(() => {
+      notification.error({
+        message: APP_NAME,
+        description: messageError
+      });
+
+      _this.setState({loading: false});
+    });
+}

--- a/src/home/ListConnected.js
+++ b/src/home/ListConnected.js
@@ -1,4 +1,8 @@
 import React, { Component } from 'react';
+import { Alert, Button, Divider, PageHeader, Space, Switch, Tooltip, Typography } from 'antd';
+import FilterOutlined from '@ant-design/icons/lib/icons/FilterOutlined';
+import ConnectedPeer from './ConnectedPeer';
+import { checkPeeringRequest, checkAdvertisement } from './HomeUtils';
 
 class ListConnected extends Component {
   constructor(props) {
@@ -7,10 +11,71 @@ class ListConnected extends Component {
   }
 
   render() {
+    let connectedPeers = [];
 
-    //TODO: create the list of connected peers
+    this.props.foreignClusters.forEach(fc => {
+
+      let client;
+      let server;
+
+      /** I am the client and I am using your resources, so check
+       * if there is an advertisement
+       */
+      if(fc.status.outgoing.joined && fc.status.outgoing.advertisement){
+        client = checkAdvertisement(this.props.advertisements, fc.status.outgoing.advertisement).adv;
+      }
+
+      /** I am the server and you are using my resources, so check
+       * if there is a peering request
+       */
+      if(fc.status.incoming.joined && fc.status.incoming.peeringRequest){
+        server = checkPeeringRequest(this.props.peeringRequests, fc.status.incoming.peeringRequest);
+      }
+
+      if(client || server){
+        connectedPeers.push(
+          <div key={fc.spec.clusterID}>
+            <ConnectedPeer {...this.props}
+                           foreignCluster={fc} client={client} server={server} />
+          </div>
+        )
+      }
+    });
+
     return (
       <div className="home-header">
+        <PageHeader style={{ paddingTop: 4, paddingBottom: 4, paddingLeft: 16, paddingRight: 16 }}
+                    title={
+                      <Space>
+                        <Typography.Text strong style={{ fontSize: 24 }}>Connected Peers</Typography.Text>
+                      </Space>
+                    }
+                    extra={
+                      <Space>
+                        <Tooltip title={'Add filter'}>
+                          {
+                            //TODO: add some filter option
+                          }
+                          <Button type={'text'} icon={<FilterOutlined/>}/>
+                        </Tooltip>
+                      </Space>
+                    }
+                    className={'draggable'}
+        />
+        <Divider style={{ marginTop: 0, marginBottom: 0 }}/>
+        { connectedPeers.length === 0 ? (
+          <div style={{ padding: '1em' }}>
+            <Alert
+              message="No peer connected at the moment"
+              description="Join one and start sharing!"
+              type="info"
+              showIcon
+              closable
+            />
+          </div>
+        ) : (
+          <div>{connectedPeers}</div>
+        )}
       </div>
     )
   }

--- a/test/AppHeader.test.js
+++ b/test/AppHeader.test.js
@@ -1,4 +1,4 @@
-import { findByLabelText, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';

--- a/test/CR.test.js
+++ b/test/CR.test.js
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 import CR from '../src/CRD/CR';
 import CRDmockResponse from '../__mocks__/crd_fetch.json';
 import LiqoDashAlteredMockResponse from '../__mocks__/liqodashtest_noSpec_noStatus.json';
-import { mockCRDAndViewsExtended, setup_resource } from './RTLUtils';
+import { setup_resource } from './RTLUtils';
 import { MemoryRouter } from 'react-router-dom';
 
 fetchMock.enableMocks();

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -1,0 +1,200 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ViewMockResponse from '../__mocks__/views.json';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../src/home/Home';
+import FCMockResponse from '../__mocks__/foreigncluster.json';
+import FCMockResponseNoIn from '../__mocks__/foreigncluster_noIncoming.json';
+import FCMockResponseNoOut from '../__mocks__/foreigncluster_noOutgoing.json';
+import PRMockResponse from '../__mocks__/peeringrequest.json';
+import AdvMockResponse from '../__mocks__/advertisement.json';
+import AdvMockResponseRefused from '../__mocks__/advertisement_refused.json';
+import AdvMockResponseNotAccepted from '../__mocks__/advertisement_notAccepted.json';
+import AdvMockResponseNoStatus from '../__mocks__/advertisement_noStatus.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import CRDmockEmpty from '../__mocks__/crd_fetch.json';
+import Error409 from '../__mocks__/409.json';
+
+fetchMock.enableMocks();
+
+let api;
+
+async function setup() {
+  api = new ApiManager();
+  api.getCRDs().then(async () => {
+    render(
+      <MemoryRouter>
+        <Home api={api} />
+      </MemoryRouter>
+    )
+  });
+}
+
+function mocks(advertisement, foreignCluster, peeringRequest, error) {
+  fetch.mockResponse((req) => {
+    if (req.url === 'http://localhost:3001/customresourcedefinition') {
+      return Promise.resolve(new Response(JSON.stringify(CRDmockEmpty)))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/views') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/foreignclusters') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+      else{
+        if(!error){
+          foreignCluster = foreignCluster.items[0];
+          foreignCluster.metadata.resourceVersion++;
+          foreignCluster.spec.join = false;
+          return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/advertisements') {
+      return Promise.resolve(new Response(JSON.stringify({ body: advertisement })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/peeringrequests') {
+      return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    }
+  })
+}
+
+describe('ConnectedPeer', () => {
+  test('List of connected peers shows', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('List of connected peers shows not incoming', async () => {
+    mocks(AdvMockResponse, FCMockResponseNoIn, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('List of connected peers shows not outgoing', async () => {
+    mocks(AdvMockResponse, FCMockResponseNoOut, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('List of connected peers show if no advertisement', async () => {
+    mocks({ items: [] }, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('List of connected peers show if no peering request', async () => {
+    mocks(AdvMockResponse, FCMockResponse, { items: [] });
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('List of connected peers doesn\'t show if no peering request and no advertisement', async () => {
+    mocks({ items: [] }, FCMockResponse, { items: [] });
+
+    await setup();
+
+    expect(await screen.queryByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).not.toBeInTheDocument();
+  })
+
+  test('Advertisement is refused', async () => {
+    mocks(AdvMockResponseRefused, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('Advertisement status is not accepted', async () => {
+    mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('Advertisement status is not accepted', async () => {
+    mocks(AdvMockResponseNoStatus, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('Clicks work', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('swap'));
+
+    expect(await screen.findByText('Properties')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('swap'));
+  })
+
+  test('Disconnection error show', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('swap'));
+
+    const disconnect = await screen.findByText('Disconnect');
+
+    userEvent.click(disconnect);
+
+    expect(await screen.findByText(/Could not disconnect/i)).toBeInTheDocument();
+
+    expect(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+
+  test('Disconnection works from dropdown menu', async () => {
+    jest.clearAllMocks();
+
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('dropdown-connected'));
+  })
+
+  test('Disconnection works', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('swap'));
+
+    const disconnect = await screen.findByText('Disconnect');
+
+    userEvent.click(disconnect);
+
+    expect(await screen.findByText(/Disconnected from/i)).toBeInTheDocument();
+
+    expect(await screen.queryByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).not.toBeInTheDocument();
+  })
+})

--- a/test/DesignEditorCRD.test.js
+++ b/test/DesignEditorCRD.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { findByRole, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
 import ApiManager from '../src/services/__mocks__/ApiManager';

--- a/test/GraphNet.test.js
+++ b/test/GraphNet.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { findByRole, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
 import CRDmockLong from '../__mocks__/crd_fetch_long.json';
@@ -11,8 +11,6 @@ import GraphNet from '../src/templates/graph/GraphNet';
 import ApiManager from '../src/services/__mocks__/ApiManager';
 
 fetchMock.enableMocks();
-
-
 
 async function setup_Graph(){
   fetch.mockImplementation((url) => {

--- a/test/Home.test.js
+++ b/test/Home.test.js
@@ -1,25 +1,11 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
-import { generalHomeGET, loginTest, mockCRDAndViewsExtended } from './RTLUtils';
+import { mockCRDAndViewsExtended } from './RTLUtils';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import CRDmockResponse from '../__mocks__/crd_fetch.json';
-import ViewMockResponse from '../__mocks__/views.json';
-import LiqoDashMockResponse from '../__mocks__/liqodashtest.json';
-import LiqoDashModifiedMockResponse from '../__mocks__/liqodashtest_modifiedCRD.json';
-import LiqoDashAlteredMockResponse from '../__mocks__/liqodashtest_noSpec_noStatus.json';
-import PieMockResponse from '../__mocks__/piecharts.json';
-import NoAnnNoResNoSch from '../__mocks__/no_Ann_noRes_noSch.json';
-import ManyResources from '../__mocks__/manyResources.json';
 import ApiManager from '../src/services/__mocks__/ApiManager';
-import CRD from '../src/CRD/CRD';
 import { MemoryRouter } from 'react-router-dom';
 import Home from '../src/home/Home';
-import FCMockResponse from '../__mocks__/foreigncluster.json';
-import AdvMockResponse from '../__mocks__/advertisement.json';
-import PRMockResponse from '../__mocks__/peeringrequest.json';
-import ConfigMockResponse from '../__mocks__/configs.json';
 
 fetchMock.enableMocks();
 


### PR DESCRIPTION
# Description

This PR adds the list of connected peers to the home view.
Each item of the list represents a join between the home cluster and a foreign cluster. It also shows the direction of the connection and the general consumption of the cluster. There's also the possibility to disconnect from a peer with a simple click.