### PR TITLE
LIQO home view - list of available peers

### DIFF
--- a/__mocks__/crd_fetch.json
+++ b/__mocks__/crd_fetch.json
@@ -1244,6 +1244,69 @@
           "v1"
         ]
       }
+    },
+    {
+      "metadata": {
+        "name": "searchdomains.discovery.liqo.io",
+        "selfLink": "/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/searchdomains.discovery.liqo.io",
+        "resourceVersion": "000000"
+      },
+      "spec": {
+        "group": "discovery.liqo.io",
+        "version": "v1",
+        "names": {
+          "plural": "searchdomains",
+          "singular": "searchdomain",
+          "shortNames": [
+            "sd"
+          ],
+          "kind": "SearchDomain",
+          "listKind": "SearchDomainList"
+        },
+        "scope": "Cluster",
+        "validation": {
+          "openAPIV3Schema": {
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+                "type": "string"
+              },
+              "kind": {
+                "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "metadata": {
+                "type": "object"
+              },
+              "spec": {
+                "required": [
+                  "domain",
+                  "autojoin"
+                ],
+                "properties": {
+                  "autojoin": {
+                    "description": "Enable join process for retrieved clusters",
+                    "type": "boolean"
+                  },
+                  "domain": {
+                    "description": "DNS domain where to search for subscribed remote clusters",
+                    "type": "string"
+                  }
+                }
+              },
+              "status": {
+                "properties": {
+                  "foreignClusters": {
+                    "description": "ForeignCluster created basing on this SearchDomain",
+                    "type": "array"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "status": {}
     }
   ]
 }

--- a/__mocks__/foreigncluster_noJoin.json
+++ b/__mocks__/foreigncluster_noJoin.json
@@ -1,0 +1,41 @@
+{
+  "apiVersion": "discovery.liqo.io/v1",
+  "items": [
+    {
+      "apiVersion": "discovery.liqo.io/v1",
+      "kind": "ForeignCluster",
+      "metadata": {
+        "labels": {
+          "cluster-id": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "discovery-type": "LAN"
+        },
+        "name": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "resourceVersion": "000000",
+        "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters/8d73c01a-f23a-45dc-822b-7d3232683f53"
+      },
+      "spec": {
+        "allowUntrustedCA": true,
+        "apiUrl": "https://1.1.1.1:1234",
+        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "discoveryType": "LAN",
+        "join": false,
+        "namespace": "liqo"
+      },
+      "status": {
+        "incoming": {
+          "joined": false
+        },
+        "outgoing": {
+          "joined": false,
+          "remote-peering-request-name": "4317f039-e7b8-40d2-ae20-18d1c47e69f0"
+        },
+        "ttl": 3
+      }
+    }
+  ],
+  "kind": "ForeignClusterList",
+  "metadata": {
+    "resourceVersion": "000000",
+    "selfLink": "/apis/discovery.liqo.io/v1/foreignclusters"
+  }
+}

--- a/__mocks__/searchdomain.json
+++ b/__mocks__/searchdomain.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "discovery.liqo.io/v1",
+  "items": [
+    {
+      "apiVersion": "discovery.liqo.io/v1",
+      "kind": "SearchDomain",
+      "metadata": {
+        "name": "search-domain-test",
+        "resourceVersion": "00000",
+        "selfLink": "/apis/discovery.liqo.io/v1/searchdomains/search-domain-test"
+      },
+      "spec": {
+        "autojoin": true,
+        "domain": ".test"
+      }
+    }
+  ]
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -8,10 +8,9 @@ jest.mock('./src/services/ApiManager');
 jest.mock('./src/services/Authenticator');
 
 jest.mock('react-ace', () => {
-  const AceEditor = ({onChange}) => {
-    return <input aria-label={'editor'} onChange={e => onChange(e.target.value)} />
-  }
-  return AceEditor;
+  return ({ onChange }) => {
+    return <input aria-label={'editor'} onChange={e => onChange(e.target.value)}/>
+  };
 });
 
 jest.mock('ace-builds/src-noconflict/mode-json', () => { return null});
@@ -20,7 +19,8 @@ jest.mock('ace-builds/src-noconflict/theme-monokai', () => { return null});
 jest.mock('ace-builds/src-noconflict/theme-github', () => { return null});
 
 jest.mock('react-graph-vis', () => {
-  const Graph = ({graph}) => {
+
+  return ({ graph }) => {
     let nodesTot = [];
     graph.nodes.forEach(node => {
       nodesTot.push(
@@ -28,12 +28,11 @@ jest.mock('react-graph-vis', () => {
       )
     })
     return (
-      <div aria-label={'graph_mock'} >
+      <div aria-label={'graph_mock'}>
         {nodesTot}
       </div>
     )
-  }
-  return Graph;
+  };
 });
 
 Object.defineProperty(window, 'matchMedia', {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "webpack -p --config webpack_docker.config.js --display-error-details",
     "prettify-all": "node_modules/.bin/prettier --write **/*.{js,json,css}",
     "lint-check": "node_modules/.bin/prettier --check **/*.{js,json,css}",
-    "test": "jest --coverage"
+    "test": "jest --coverage --silent"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",

--- a/src/home/AvailablePeer.js
+++ b/src/home/AvailablePeer.js
@@ -142,7 +142,7 @@ class AvailablePeer extends Component {
             }
             extra={
               <span aria-label={'dropdown-available'} onClick={event => {event.stopPropagation()}}>
-                <Dropdown.Button overlay={menu} trigger={['click']} icon={<EllipsisOutlined />}/>
+                <Dropdown.Button overlay={menu} trigger={['click']} icon={<EllipsisOutlined />} />
               </span>
             }
             showArrow={false}

--- a/src/home/AvailablePeer.js
+++ b/src/home/AvailablePeer.js
@@ -1,0 +1,194 @@
+import React, { Component } from 'react';
+import {
+  Space, Dropdown, Menu,
+  Row, Tooltip,
+  Avatar, Tag, Collapse, Typography, Button, Tabs, Modal, Col
+} from 'antd';
+import LinkOutlined from '@ant-design/icons/lib/icons/LinkOutlined';
+import ToolOutlined from '@ant-design/icons/lib/icons/ToolOutlined';
+import StarOutlined from '@ant-design/icons/lib/icons/StarOutlined';
+import EllipsisOutlined from '@ant-design/icons/lib/icons/EllipsisOutlined';
+import WifiOutlined from '@ant-design/icons/lib/icons/WifiOutlined';
+import GlobalOutlined from '@ant-design/icons/lib/icons/GlobalOutlined';
+import LoadingOutlined from '@ant-design/icons/lib/icons/LoadingOutlined';
+import CloseOutlined from '@ant-design/icons/lib/icons/CloseOutlined';
+import ClusterOutlined from '@ant-design/icons/lib/icons/ClusterOutlined';
+
+import { updatePeeringStatus } from './HomeUtils';
+
+class AvailablePeer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      lan: false,
+      loading: false,
+      backgroundColor: 'white'
+    }
+
+    this.join = this.join.bind(this);
+    this.disconnect = this.disconnect.bind(this);
+  }
+
+  join() {
+    this.props.foreignCluster.spec.join = true;
+
+    updatePeeringStatus(this,
+      'Connecting to ' + this.props.foreignCluster.metadata.name,
+      'Could not connect');
+  }
+
+  componentWillUnmount() {
+    this.state.backGroundColor = 'white';
+  }
+
+  disconnect() {
+    this.props.foreignCluster.spec.join = false;
+
+    updatePeeringStatus(this,
+      'Stopping trying to connect to ' + this.props.foreignCluster.metadata.name,
+      'Could not disconnect');
+  }
+
+  render() {
+
+    this.state.lan = this.props.foreignCluster.spec.discoveryType === 'LAN';
+
+    this.state.loading = !!this.props.foreignCluster.spec.join;
+
+    if(this.props.refused){
+      this.state.loading = false;
+    }
+
+    const menu = (
+      <Menu>
+        {this.state.loading ? (
+          <Menu.Item key={'connect'} icon={<LinkOutlined />} onClick={() => {this.disconnect()}}>
+            Stop Connecting
+          </Menu.Item>
+        ) : (
+          <Menu.Item key={'connect'} icon={<LinkOutlined />} onClick={() => {this.join()}}>
+            Connect
+          </Menu.Item>
+        )}
+        <Menu.Item key={'properties'} icon={<ToolOutlined />}>
+          Properties
+        </Menu.Item>
+        <Menu.Item key={'favourite'} icon={<StarOutlined />}>
+          Favourite
+        </Menu.Item>
+      </Menu>
+    )
+
+    return (
+      <div>
+        <div style={{ paddingTop: '1em', paddingBottom: '1em' }}>
+          <Collapse accordion bordered={false}
+                    style={{backgroundColor: this.state.backgroundColor}}
+                    onChange={(collapsed) => {
+                      if(collapsed){
+                        this.setState({backgroundColor: '#e6f7ff'})
+                      } else {
+                        this.setState({backgroundColor: 'white'})
+                      }
+                    }}
+          >
+            <Collapse.Panel header={
+              <Space size={'large'}>
+                <div>
+                  <Row justify={'center'}>
+                    <Tooltip placement={'top'} title={
+                      this.props.refused ?
+                        this.props.reason
+                        :
+                        this.state.lan ? 'Connect through LAN' : 'Connect through Internet'
+                    }>
+                      <div onClick={() => this.join()}>
+                        <Avatar.Group>
+                          <Avatar
+                            size="large"
+                            style={{
+                              backgroundColor: '#1890ff',
+                            }}
+                            //src={require('../assets/database.png')}
+                            icon={<ClusterOutlined />}
+                          />
+                          <Avatar
+                            size="small"
+                            style={this.props.refused ?
+                              {
+                                backgroundColor: '#f5222d'
+                              } : {
+                                backgroundColor: '#87d068'
+                              }
+                            }
+                            icon={
+                              this.props.refused ? <CloseOutlined /> :
+                                this.state.loading ? <LoadingOutlined/> :
+                                this.state.lan ? <WifiOutlined/> : <GlobalOutlined/>
+                            }
+                          />
+                        </Avatar.Group>
+                      </div>
+                    </Tooltip>
+                  </Row>
+                </div>
+                <Tooltip placement={'top'} title={this.props.foreignCluster.spec.clusterID}>
+                  <Tag color="blue" style={{ maxWidth: '13vw', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                    {this.props.foreignCluster.spec.clusterID}
+                  </Tag>
+                </Tooltip>
+              </Space>
+            }
+            extra={
+              <span aria-label={'dropdown-available'} onClick={event => {event.stopPropagation()}}>
+                <Dropdown.Button overlay={menu} trigger={['click']} icon={<EllipsisOutlined />}/>
+              </span>
+            }
+            showArrow={false}
+            key={this.props.foreignCluster.metadata.name + '_available'}
+            style={{border: 0}}
+            >
+              <div style={{paddingLeft: '1em', paddingBottom: '1em'}}>
+                <Row align={'middle'}>
+                  <Col flex={2}>
+                    <Typography.Text type={'secondary'}>
+                      { this.props.refused ?
+                        this.props.reason
+                        :
+                        this.props.foreignCluster.spec.discoveryType
+                      }
+                      { this.state.loading && !this.props.refused ?
+                        <span>, <>{this.props.reason ? this.props.reason : 'connecting...'}</></span>
+                        :
+                        null
+                      }
+                    </Typography.Text>
+                  </Col>
+                  <Col flex={3}>
+                    <div style={{float: 'right'}}>
+                      <Button style={{marginRight: '1em'}}>
+                        Properties
+                      </Button>
+                      { this.state.loading ? (
+                        <Button style={{ float: 'right' }} type={'danger'} onClick={() => this.disconnect()}>
+                          Stop Connecting
+                        </Button>
+                      ) : (
+                        <Button style={{ float: 'right' }} type={'primary'} onClick={() => this.join()}>
+                          Connect
+                        </Button>
+                      )}
+                    </div>
+                  </Col>
+                </Row>
+              </div>
+            </Collapse.Panel>
+          </Collapse>
+        </div>
+      </div>
+    )
+  }
+}
+
+export default AvailablePeer;

--- a/src/home/Home.js
+++ b/src/home/Home.js
@@ -217,7 +217,9 @@ class Home extends Component {
       >
         <Alert.ErrorBoundary>
           <ListConnected api={this.props.api} config={this.state.config}
-                         foreignClusters={this.state.foreignClusters.filter(fc => {return ((fc.status.outgoing.joined || fc.status.incoming.joined) && fc.spec.join)})}
+                         foreignClusters={this.state.foreignClusters.filter(fc =>
+                          {return ( fc.spec.join && fc.status && (fc.status.outgoing.joined || fc.status.incoming.joined))}
+                         )}
                          advertisements={this.state.advertisements}
                          peeringRequests={this.state.peeringRequests}
           />

--- a/src/home/ListAvailable.js
+++ b/src/home/ListAvailable.js
@@ -1,18 +1,168 @@
 import React, { Component } from 'react';
+import { Alert, Button, Divider, Modal, notification, PageHeader, Space, Tabs, Tooltip, Typography } from 'antd';
+import PlusOutlined from '@ant-design/icons/lib/icons/PlusOutlined';
+import FormGenerator from '../editors/OAPIV3FormGenerator/FormGenerator';
+import AvailablePeer from './AvailablePeer';
+import { checkAdvertisement, checkPeeringRequest } from './HomeUtils';
+import { APP_NAME } from '../constants';
 
 class ListAvailable extends Component {
   constructor(props) {
     super(props);
+
+    this.state = {
+      showAddPeer: false,
+    }
+
+    this.submit = this.submit.bind(this);
+  }
+
+  submit(item){
+    let CRD = this.props.api.getCRDfromKind(item.kind)
+
+    //let namespace = '';
+
+    /*if(CRD.spec.scope === 'Namespaced'){
+      namespace = 'default';
+    }
+
+    if(item.metadata.namespace) {
+      namespace = item.metadata.namespace;
+    }*/
+
+    this.setState({isLoading: true});
+
+    let promise = this.props.api.createCustomResource(
+      CRD.spec.group,
+      CRD.spec.version,
+      null,
+      CRD.spec.names.plural,
+      item
+    );
+
+    promise
+      .then(() => {
+        this.setState({
+          isLoading: false
+        });
+        notification.success({
+          message: APP_NAME,
+          description: 'Peer added'
+        });
+      })
+      .catch((error) => {
+        console.log(error);
+        this.setState({
+          isLoading: false
+        });
+        notification.error({
+          message: APP_NAME,
+          description: 'Could not add peer'
+        });
+      });
   }
 
   render() {
 
-    //TODO: create the list of available peers
-    return (
-      <div className="home-header">
+    let availablePeers = [];
+
+    this.props.foreignClusters.forEach(fc => {
+
+      let visibleP = true;
+      let visibleA = true;
+      let reason = '';
+      let refused = false;
+
+      /** If foreign cluster is already joined, don't show */
+      if (fc.spec.join && fc.status){
+        if(fc.status.outgoing.joined && fc.status.outgoing.advertisement){
+          let adv = checkAdvertisement(this.props.advertisements, fc.status.outgoing.advertisement);
+          visibleA = !adv.adv;
+          reason = adv.reason;
+          if(adv.reason === 'Advertisement Refused'){
+            refused = true;
+          }
+        }
+        if(fc.status.incoming.joined && fc.status.incoming.peeringRequest){
+          visibleP = !checkPeeringRequest(this.props.peeringRequests, fc.status.incoming.peeringRequest);
+        }
+      }
+
+      if(visibleA && visibleP){
+        availablePeers.push(
+          <div key={fc.spec.clusterID}>
+            <AvailablePeer {...this.props} foreignCluster={fc}
+                           refused={refused} reason={reason}
+            />
+          </div>
+        )
+      }
+    });
+
+    const availablePeersCard = (
+      <div>
+        <PageHeader style={{paddingTop: 4, paddingBottom: 4, paddingLeft: 16, paddingRight: 16}}
+                    title={
+                      <div className={'draggable'}>
+                        <Typography.Text strong style={{fontSize: 24}}>Available Peers</Typography.Text>
+                      </div>
+                    }
+                    extra={
+                      <Tooltip title={'Add new peer'}>
+                        <Button type={'primary'}
+                                onClick={() => {
+                                  this.setState({showAddPeer: true});
+                                }}
+                                icon={<PlusOutlined />} style={{marginTop: 2}}/>
+                      </Tooltip>
+                    }
+        />
+        <Divider style={{marginTop: 0, marginBottom: 0}}/>
+        { availablePeers.length === 0 ? (
+          <div style={{ padding: '1em' }}>
+            <Alert
+              message="No peer available at the moment"
+              description={
+                <Typography.Link underline onClick={() => {this.setState({showAddPeer: true})}}>
+                  Search for one
+                </Typography.Link>
+              }
+              type="info"
+              showIcon
+              closable
+            />
+          </div>
+        ) : (
+          <div>{availablePeers}</div>
+        )}
       </div>
     )
 
+    return (
+      <div className="home-header">
+        {availablePeersCard}
+        <div>
+          { /** This modal let the user add a peer by creating a new foreign cluster or search domain */ }
+          <Modal
+            visible={this.state.showAddPeer}
+            onCancel={() => {this.setState({showAddPeer: false})}}
+            bodyStyle={{paddingTop: 0}}
+            width={'30vw'}
+            footer={null}
+            destroyOnClose
+          >
+            <Tabs>
+              <Tabs.TabPane tab={'Add domain'} key={1}>
+                <FormGenerator CRD={this.props.api.getCRDfromKind('SearchDomain')} submit={this.submit}/>
+              </Tabs.TabPane>
+              <Tabs.TabPane tab={'Add remote peer'} key={2}>
+                <FormGenerator CRD={this.props.api.getCRDfromKind('ForeignCluster')} submit={this.submit}/>
+              </Tabs.TabPane>
+            </Tabs>
+          </Modal>
+        </div>
+      </div>
+    )
   }
 }
 

--- a/src/services/__mocks__/ApiManager.js
+++ b/src/services/__mocks__/ApiManager.js
@@ -178,10 +178,12 @@ export default class ApiManager {
     return fetch('http://localhost:3001/clustercustomobject/' + plural, { method: 'POST', body: item})
       .then(res => res.json())
       .then((res) => {
+
         this.watchers.forEach(w => {
           if (w.plural === plural)
             w.callback('ADDED', res.body);
         })
+
       });
   }
 
@@ -202,10 +204,15 @@ export default class ApiManager {
       itemDC.metadata.resourceVersion++;
       this.CVsNotifyEvent('MODIFIED', itemDC);
       return Promise.resolve(new Response(JSON.stringify(item)))
-    } else if (plural === 'liqodashtests' || plural === 'clusterconfigs' || plural === 'foreignclusters') {
+    } else if (plural === 'liqodashtests' ||
+      plural === 'clusterconfigs' ||
+      plural === 'foreignclusters' ||
+      plural === 'searchdomains'
+    ) {
       return fetch('http://localhost:3001/clustercustomobject/' + plural, { method: 'PUT', body: item})
         .then(res => res.json())
         .then((res) => {
+          //console.log(res)
           this.watchers.forEach(w => {
             if (w.plural === plural)
               w.callback('MODIFIED', res.body);

--- a/test/AvailableList.test.js
+++ b/test/AvailableList.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ViewMockResponse from '../__mocks__/views.json';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../src/home/Home';
+import FCMockResponse from '../__mocks__/foreigncluster_noJoin.json';
+import PRMockResponse from '../__mocks__/peeringrequest.json';
+import AdvMockResponse from '../__mocks__/advertisement.json';
+import SDMockResponse from '../__mocks__/searchdomain.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import CRDmockEmpty from '../__mocks__/crd_fetch.json';
+import Error409 from '../__mocks__/409.json';
+
+fetchMock.enableMocks();
+
+let api;
+
+async function setup() {
+  api = new ApiManager();
+  api.getCRDs().then(async () => {
+    render(
+      <MemoryRouter>
+        <Home api={api} />
+      </MemoryRouter>
+    )
+  });
+}
+
+function mocks(advertisement, foreignCluster, peeringRequest, error) {
+  fetch.mockResponse((req) => {
+    if (req.url === 'http://localhost:3001/customresourcedefinition') {
+      return Promise.resolve(new Response(JSON.stringify(CRDmockEmpty)))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/views') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/foreignclusters') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+      else{
+        if(!error){
+          foreignCluster = foreignCluster.items[0];
+          foreignCluster.metadata.resourceVersion++;
+          foreignCluster.spec.join = false;
+          return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/searchdomains') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: SDMockResponse })));
+      else{
+        if(!error){
+          let searchDomain = SDMockResponse.items[0];
+          searchDomain.metadata.resourceVersion++;
+          return Promise.resolve(new Response(JSON.stringify({ body: searchDomain })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/advertisements') {
+      return Promise.resolve(new Response(JSON.stringify({ body: advertisement })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/peeringrequests') {
+      return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    }
+  })
+}
+
+async function OKCheck() {
+  await setup();
+
+  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
+}
+
+describe('AvailableList', () => {
+
+  test('Close the modal', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('plus'));
+
+    let close = await screen.findAllByLabelText('close');
+
+    userEvent.click(close[1]);
+
+    setTimeout(() => {
+      expect(screen.queryByText(/add domain/i)).not.toBeInTheDocument();
+    }, 1500);
+
+    userEvent.click(screen.getByLabelText('plus'));
+
+  }, 30000)
+
+})

--- a/test/AvailablePeer.test.js
+++ b/test/AvailablePeer.test.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ViewMockResponse from '../__mocks__/views.json';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../src/home/Home';
+import FCMockResponse from '../__mocks__/foreigncluster_noJoin.json';
+import FCMockResponseJoin from '../__mocks__/foreigncluster.json';
+import FCMockResponseNoIn from '../__mocks__/foreigncluster_noIncoming.json';
+import FCMockResponseNoOut from '../__mocks__/foreigncluster_noOutgoing.json';
+import PRMockResponse from '../__mocks__/peeringrequest.json';
+import AdvMockResponse from '../__mocks__/advertisement.json';
+import SDMockResponse from '../__mocks__/searchdomain.json';
+import AdvMockResponseRefused from '../__mocks__/advertisement_refused.json';
+import AdvMockResponseNotAccepted from '../__mocks__/advertisement_notAccepted.json';
+import AdvMockResponseNoStatus from '../__mocks__/advertisement_noStatus.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import CRDmockEmpty from '../__mocks__/crd_fetch.json';
+import Error409 from '../__mocks__/409.json';
+
+fetchMock.enableMocks();
+
+let api;
+
+async function setup() {
+  api = new ApiManager();
+  api.getCRDs().then(async () => {
+    render(
+      <MemoryRouter>
+        <Home api={api} />
+      </MemoryRouter>
+    )
+  });
+}
+
+function mocks(advertisement, foreignCluster, peeringRequest, error) {
+  fetch.mockResponse((req) => {
+    if (req.url === 'http://localhost:3001/customresourcedefinition') {
+      return Promise.resolve(new Response(JSON.stringify(CRDmockEmpty)))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/views') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/foreignclusters') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+      else{
+        if(!error){
+          let foreignCluster = FCMockResponseNoIn.items[0];
+          foreignCluster.metadata.resourceVersion++;
+          return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/searchdomains') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: SDMockResponse })));
+      else{
+        if(!error){
+          let searchDomain = SDMockResponse.items[0];
+          searchDomain.metadata.resourceVersion++;
+          return Promise.resolve(new Response(JSON.stringify({ body: searchDomain })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/advertisements') {
+      return Promise.resolve(new Response(JSON.stringify({ body: advertisement })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/peeringrequests') {
+      return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    }
+  })
+}
+
+async function OKCheck() {
+  await setup();
+
+  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
+}
+
+async function addPeer() {
+  userEvent.click(screen.getByLabelText('plus'));
+
+  let textbox = await screen.findAllByRole('textbox');
+
+  await userEvent.type(textbox[0], 'test');
+  await userEvent.type(textbox[1], 'domain-test');
+
+  userEvent.click(screen.getByRole('switch'));
+
+  expect(screen.getByText('Submit')).toBeInTheDocument();
+
+  userEvent.click(screen.getByText('Submit'));
+}
+
+describe('AvailablePeer', () => {
+  test('List of available peers shows', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('dropdown-available'));
+  })
+
+  test('Add manual peer works', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    await addPeer();
+
+    expect(await screen.findByText(/Peer Added/i)).toBeInTheDocument();
+  }, 30000)
+
+  test('Add manual peer with error shows notification', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
+
+    await OKCheck();
+
+    await addPeer();
+
+    expect(await screen.findByText(/Could not add peer/i)).toBeInTheDocument();
+  }, 30000)
+
+  test('Modal opens when click on search for domain', async () => {
+    mocks(AdvMockResponse, FCMockResponseJoin, PRMockResponse);
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText(/No peer available/i)).toBeInTheDocument();
+
+    userEvent.click(await screen.findByText(/search/i));
+  })
+
+  test('Connect with a cluster', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+    await OKCheck();
+
+    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+
+    expect(await screen.findByText('Connect')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Connect'));
+
+    expect(await screen.findByText(/No peer available/i)).toBeInTheDocument();
+  })
+
+  test('Connect with a cluster from dropdown', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('ellipsis'));
+
+    screen.debug(await screen.findByLabelText('link'));
+
+    userEvent.click(await screen.findByLabelText('link'));
+
+  }, 30000)
+
+  test('Connect through WAN', async () => {
+    let fcRes = FCMockResponse;
+    fcRes.items[0].spec.discoveryType = 'WAN';
+
+    mocks(AdvMockResponse, fcRes, PRMockResponse);
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('cluster'));
+
+    expect(await screen.findByText(/No peer available/i)).toBeInTheDocument();
+  })
+
+  test('Connect with a cluster then disconnect', async () => {
+    mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);
+    await OKCheck();
+
+    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+
+    expect(await screen.findByText('Connect')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Connect'));
+
+    expect(await screen.findByText(/No peer connected/i)).toBeInTheDocument();
+
+    userEvent.click(await screen.findByText('Stop Connecting'));
+
+    expect(await screen.findByText('Connect')).toBeInTheDocument();
+  })
+
+  test('Connect with a cluster then disconnect from dropdown', async () => {
+    mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('ellipsis'));
+
+    userEvent.click(await screen.findByLabelText('link'));
+
+    userEvent.click(screen.getByLabelText('ellipsis'));
+
+    userEvent.click(await screen.findByLabelText('link'));
+
+  }, 30000)
+
+  test('Connect with a cluster with error', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
+    await OKCheck();
+
+    userEvent.click(screen.getAllByText('8d73c01a-f23a-45dc-822b-7d3232683f53')[0]);
+
+    expect(await screen.findByText('Connect')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Connect'));
+
+    expect(await screen.findByText(/No peer connected/i)).toBeInTheDocument();
+
+    userEvent.click(screen.getAllByText('8d73c01a-f23a-45dc-822b-7d3232683f53')[0]);
+  })
+
+})

--- a/test/CRDList.test.js
+++ b/test/CRDList.test.js
@@ -20,7 +20,7 @@ async function setup() {
   const customview = screen.getByText('Custom Resources');
   userEvent.click(customview);
 
-  expect(screen.getAllByRole('row')).toHaveLength(CRDMockResponseShort.items.length);
+  expect(screen.getAllByRole('row')).toHaveLength(11);
 }
 
 describe('CRD List', () => {
@@ -40,7 +40,7 @@ describe('CRD List', () => {
     const customview = screen.getByText('Custom Resources');
     userEvent.click(customview);
 
-    expect(screen.getAllByRole('row')).toHaveLength(CRDMockResponseShort.items.length);
+    expect(screen.getAllByRole('row')).toHaveLength(11);
 
     userEvent.click(screen.getByText('2'));
 
@@ -53,7 +53,7 @@ describe('CRD List', () => {
 
     expect(screen.getByText('protocol.liqo.io'));
     expect(screen.getByText('Advertisement'));
-    expect(screen.getAllByText('This CRD has no description')).toHaveLength(CRDMockResponseShort.items.length - 4);
+    expect(screen.getAllByText('This CRD has no description')).toHaveLength(11 - 4);
 
     expect(screen.getByText('This CRD is used to create custom views from a set of CRDs'));
   })

--- a/test/ConnectedList.test.js
+++ b/test/ConnectedList.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ViewMockResponse from '../__mocks__/views.json';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../src/home/Home';
+import FCMockResponse from '../__mocks__/foreigncluster.json';
+import PRMockResponse from '../__mocks__/peeringrequest.json';
+import AdvMockResponse from '../__mocks__/advertisement.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import CRDmockEmpty from '../__mocks__/crd_fetch.json';
+import Error409 from '../__mocks__/409.json';
+
+fetchMock.enableMocks();
+
+let api;
+
+async function setup() {
+  api = new ApiManager();
+  api.getCRDs().then(async () => {
+    render(
+      <MemoryRouter>
+        <Home api={api} />
+      </MemoryRouter>
+    )
+  });
+}
+
+function mocks(advertisement, foreignCluster, peeringRequest, error) {
+  fetch.mockResponse((req) => {
+    if (req.url === 'http://localhost:3001/customresourcedefinition') {
+      return Promise.resolve(new Response(JSON.stringify(CRDmockEmpty)))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/views') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/foreignclusters') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+      else{
+        if(!error){
+          foreignCluster = foreignCluster.items[0];
+          foreignCluster.metadata.resourceVersion++;
+          foreignCluster.spec.join = false;
+          return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/advertisements') {
+      return Promise.resolve(new Response(JSON.stringify({ body: advertisement })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/peeringrequests') {
+      return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    }
+  })
+}
+
+async function OKCheck() {
+  await setup();
+
+  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
+}
+
+describe('ConnectedList', () => {
+  test('Disconnection error from dropdown show', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
+
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('ellipsis'));
+
+    await screen.getByLabelText('snippets');
+
+    const disconnect = await screen.findAllByLabelText('close');
+
+    userEvent.click(disconnect[0]);
+    userEvent.click(disconnect[1]);
+
+    expect(await screen.findByText(/Could not disconnect/i)).toBeInTheDocument();
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  })
+})

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -63,45 +63,42 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
   })
 }
 
+async function OKCheck() {
+  await setup();
+
+  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
+}
+
 describe('ConnectedPeer', () => {
   test('List of connected peers shows', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('List of connected peers shows not incoming', async () => {
     mocks(AdvMockResponse, FCMockResponseNoIn, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('List of connected peers shows not outgoing', async () => {
     mocks(AdvMockResponse, FCMockResponseNoOut, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('List of connected peers show if no advertisement', async () => {
     mocks({ items: [] }, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('List of connected peers show if no peering request', async () => {
     mocks(AdvMockResponse, FCMockResponse, { items: [] });
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('List of connected peers doesn\'t show if no peering request and no advertisement', async () => {
@@ -109,39 +106,32 @@ describe('ConnectedPeer', () => {
 
     await setup();
 
-    expect(await screen.queryByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).not.toBeInTheDocument();
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
   })
 
   test('Advertisement is refused', async () => {
     mocks(AdvMockResponseRefused, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('Advertisement status is not accepted', async () => {
     mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('Advertisement status is not accepted', async () => {
     mocks(AdvMockResponseNoStatus, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
   })
 
   test('Clicks work', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
 
     userEvent.click(screen.getByLabelText('swap'));
 
@@ -153,9 +143,7 @@ describe('ConnectedPeer', () => {
   test('Disconnection error show', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
 
     userEvent.click(screen.getByLabelText('swap'));
 
@@ -164,18 +152,16 @@ describe('ConnectedPeer', () => {
     userEvent.click(disconnect);
 
     expect(await screen.findByText(/Could not disconnect/i)).toBeInTheDocument();
-
-    expect(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
   })
 
-  test('Disconnection works from dropdown menu', async () => {
+  test('Dropdown menu don\'t activate collapse', async () => {
     jest.clearAllMocks();
 
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
 
     userEvent.click(screen.getByLabelText('dropdown-connected'));
   })
@@ -183,9 +169,7 @@ describe('ConnectedPeer', () => {
   test('Disconnection works', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
 
-    await setup();
-
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    await OKCheck();
 
     userEvent.click(screen.getByLabelText('swap'));
 
@@ -195,6 +179,7 @@ describe('ConnectedPeer', () => {
 
     expect(await screen.findByText(/Disconnected from/i)).toBeInTheDocument();
 
-    expect(await screen.queryByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).not.toBeInTheDocument();
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
   })
 })

--- a/test/RTLUtils.js
+++ b/test/RTLUtils.js
@@ -48,9 +48,9 @@ function responseManager(req, error, method, crd, crd_v, res_get, res_post, res_
     if (error && method === 'POST') {
       if (error === '409') {
         return Promise.reject(Error409.body);
-      } else {
+      } /*else {
         return Promise.reject(Error401.body);
-      }
+      }*/
     } else {
       return Promise.resolve(new Response(JSON.stringify({ body: res_post })));
     }
@@ -58,9 +58,9 @@ function responseManager(req, error, method, crd, crd_v, res_get, res_post, res_
     if (error && method === 'PUT') {
       if (error === '409') {
         return Promise.reject(Error409.body);
-      } else {
+      } /*else {
         return Promise.reject(Error401.body);
-      }
+      }*/
     } else {
       return Promise.resolve(new Response(JSON.stringify({ body: res_put })));
     }

--- a/test/SideBar.test.js
+++ b/test/SideBar.test.js
@@ -39,7 +39,7 @@ describe('Sidebar', () => {
     const customview = await screen.findByText('Custom Resources');
     userEvent.click(customview);
 
-    expect(await screen.findAllByRole('row')).toHaveLength(CRDmockResponse.items.length);
+    expect(await screen.findAllByRole('row')).toHaveLength(11);
   })
 
   test('Sidebar favourite redirect is ok', async () => {


### PR DESCRIPTION
# Description
This PR adds the list of available peers to the home view.
Each item of the list represents a peer (foreign cluster) that has been discovered and can be joined with the home cluster. It also shows the type of the connection (if the foreign cluster is in the same LAN as the home cluster or not). There's the possibility to connect to connect with a peer with a simple click. It also describes the status of the connecting process and, in case of connection error, in what phase of the connecting process the error has shown.