### PR TITLE
LIQO home view -peer connection details

### DIFF
--- a/__mocks__/advertisement.json
+++ b/__mocks__/advertisement.json
@@ -236,7 +236,10 @@
           "name": "",
           "namespace": ""
         },
-        "vkCreated": true
+        "vkCreated": true,
+        "vkReference": {
+          "name": "vk-test"
+        }
       }
     }
   ],

--- a/__mocks__/pods.json
+++ b/__mocks__/pods.json
@@ -1,0 +1,331 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/pods",
+    "resourceVersion": "00000"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-x66v9",
+        "generateName": "hello-world-deployment-6756549f5-",
+        "namespace": "test",
+        "selfLink": "/api/v1/namespaces/test/pods/hello-world-deployment-6756549f5-x66v9",
+        "labels": {
+          "app": "hello-world",
+          "pod-template-hash": "6756549f5"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "name": "hello-world-deployment-6756549f5",
+            "uid": "419b8224-d91f-4f83-b972-e0fe158d7500",
+            "controller": true,
+            "blockOwnerDeletion": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-mbjjj",
+            "secret": {
+              "secretName": "default-token-mbjjj",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "hello-world",
+            "image": "bhargavshah86/kube-test:v0.1",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "250m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "80m",
+                "memory": "128Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-mbjjj",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "vk-test",
+        "securityContext": {
+
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "virtual-node.liqo.io/not-allowed",
+            "operator": "Exists",
+            "effect": "NoExecute"
+          },
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Running"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-c7qzv",
+        "namespace": "test-c22b84e7-dcb9-483f-8009-29f16c911388",
+        "selfLink": "/api/v1/namespaces/test-c22b84e7-dcb9-483f-8009-29f16c911388/pods/hello-world-deployment-6756549f5-c7qzv",
+        "uid": "1cbea8ae-6298-42a6-8667-b75cdc7e26f8",
+        "resourceVersion": "14358",
+        "creationTimestamp": "2020-08-18T14:48:22Z",
+        "labels": {
+          "app": "hello-world",
+          "pod-template-hash": "6756549f5"
+        },
+        "annotations": {
+          "home_creationTimestamp": "2020-08-18 14:48:22 +0000 UTC",
+          "home_nodename": "vk-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
+          "home_resourceVersion": "13731",
+          "home_uuid": "e1dce48a-60b0-4368-8d83-d2d2b9589cd1"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-l6gv9",
+            "secret": {
+              "secretName": "default-token-l6gv9",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "hello-world",
+            "image": "bhargavshah86/kube-test:v0.1",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "250m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "80m",
+                "memory": "128Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-l6gv9",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "node0",
+        "securityContext": {
+
+        },
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "type",
+                      "operator": "NotIn",
+                      "values": [
+                        "virtual-node"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Pending"
+      }
+    },
+    {
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-c7sx8",
+        "namespace": "test-c22b84e7-dcb9-483f-8009-29f16c911388",
+        "selfLink": "/api/v1/namespaces/test-c22b84e7-dcb9-483f-8009-29f16c911388/pods/hello-world-deployment-6756549f5-c7sx8",
+        "uid": "076aed36-8bf0-4855-b2bd-4902e55185c9",
+        "resourceVersion": "14367",
+        "creationTimestamp": "2020-08-18T14:48:24Z",
+        "labels": {
+          "app": "hello-world",
+          "pod-template-hash": "6756549f5"
+        },
+        "annotations": {
+          "home_creationTimestamp": "2020-08-18 14:48:22 +0000 UTC",
+          "home_nodename": "vk-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
+          "home_resourceVersion": "13728",
+          "home_uuid": "16bc4174-b9d1-4fff-a994-bcba1aabfd24"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-l6gv9",
+            "secret": {
+              "secretName": "default-token-l6gv9",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "hello-world",
+            "image": "bhargavshah86/kube-test:v0.1",
+            "ports": [
+              {
+                "containerPort": 80,
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "250m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "80m",
+                "memory": "128Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "default-token-l6gv9",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "imagePullPolicy": "IfNotPresent"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "liqo1-control-plane",
+        "securityContext": {
+
+        },
+        "affinity": {
+          "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "type",
+                      "operator": "NotIn",
+                      "values": [
+                        "virtual-node"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "schedulerName": "default-scheduler",
+        "tolerations": [
+          {
+            "key": "node.kubernetes.io/not-ready",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          },
+          {
+            "key": "node.kubernetes.io/unreachable",
+            "operator": "Exists",
+            "effect": "NoExecute",
+            "tolerationSeconds": 300
+          }
+        ],
+        "priority": 0,
+        "enableServiceLinks": true
+      },
+      "status": {
+        "phase": "Running"
+      }
+    }
+  ]
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,3 @@
 export const APP_NAME = 'LiqoDash';
 export const TEMPLATE_GROUP = 'crd-template.liqo.com'
+export const LIQO_LABEL_ENABLED = 'liqo.io/enabled=true'

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -1,0 +1,313 @@
+import React, { Component } from 'react';
+import {
+  Modal, Tabs, Typography, Tag, Badge, Space,
+  Row, Col, Card, Progress, Input, Button, Table
+} from 'antd';
+import InfoCircleOutlined from '@ant-design/icons/lib/icons/InfoCircleOutlined';
+import HomeOutlined from '@ant-design/icons/lib/icons/HomeOutlined';
+import GlobalOutlined from '@ant-design/icons/lib/icons/GlobalOutlined';
+import { getColor } from './HomeUtils';
+import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
+
+class ConnectionDetails extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentTab: '1'
+    }
+  }
+
+  getUsedPODCPU(role){
+    //TODO: retrieve pod CPU consumption percentage
+    return 10;
+  }
+
+  getUsedPODRAM(role){
+    //TODO: retrieve pod RAM consumption percentage
+    return 10;
+  }
+
+  getUsedPODStorage(role){
+    //TODO: retrieve pod Storage consumption percentage
+    return 10;
+  }
+
+  getUsedTotalCPU(role){
+    //TODO: retrieve pods total CPU consumption percentage
+    return 90;
+  }
+
+  getUsedTotalRAM(role){
+    //TODO: retrieve pods total RAM consumption percentage
+    return 20;
+  }
+
+  getUsedTotalStorage(role){
+    //TODO: retrieve pods total Storage consumption percentage
+    return 75;
+  }
+
+  PODtoTable(pods){
+
+    let searchText = '';
+    let searchedColumn = '';
+
+    const handleSearch = (selectedKeys, confirm, dataIndex) => {
+      confirm();
+      searchText = selectedKeys[0];
+      searchedColumn = dataIndex;
+    };
+
+    const handleReset = clearFilters => {
+      clearFilters();
+      searchText = '' ;
+    };
+
+    const getColumnSearchProps = dataIndex => ({
+      filterDropdown: ({ setSelectedKeys, selectedKeys, confirm, clearFilters }) => (
+        <div style={{ padding: 8 }}>
+          <Input
+            ref={node => {
+              searchText = node;
+            }}
+            placeholder={`Search ${dataIndex}`}
+            value={selectedKeys[0]}
+            onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
+            onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
+            style={{ width: 188, marginBottom: 8, display: 'block' }}
+          />
+          <Space>
+            <Button
+              type="primary"
+              onClick={() => handleSearch(selectedKeys, confirm, dataIndex)}
+              icon={<SearchOutlined />}
+              size="small"
+              style={{ width: 90 }}
+            >
+              Search
+            </Button>
+            <Button onClick={() => handleReset(clearFilters)} size="small" style={{ width: 90 }}>
+              Reset
+            </Button>
+          </Space>
+        </div>
+      ),
+      filterIcon: filtered => <SearchOutlined style={{ color: filtered ? '#1890ff' : undefined }} />,
+      onFilter: (value, record) =>
+        record[dataIndex] ? record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()) : '',
+      onFilterDropdownVisibleChange: visible => {
+        if (visible) {
+          setTimeout(() => searchText.select());
+        }
+      },
+      render: text =>
+        dataIndex === 'Status' ? (
+          text === 'Running' ? <Tag color={'blue'}>{text}</Tag> : <Tag color={'red'}>{text}</Tag>
+        ) : (
+          text
+        ),
+    });
+
+    const column = [
+      {
+        title: 'Name',
+        dataIndex: 'Name',
+        key: 'Name',
+        ...getColumnSearchProps('Name')
+      },
+      {
+        title: 'Status',
+        dataIndex: 'Status',
+        key: 'Status',
+        ...getColumnSearchProps('Status')
+      },
+      {
+        title: 'CPU (%)',
+        dataIndex: 'CPU',
+        key: 'CPU',
+        render: text => <Progress percent={text}
+                                  status={'active'}
+                                  strokeColor={getColor(text)}
+        />,
+        sorter: {
+          compare: (a, b) => a.CPU - b.CPU
+        },
+      },
+      {
+        title: 'RAM (MB)',
+        dataIndex: 'RAM',
+        key: 'RAM',
+        render: text => <Progress percent={(text/999)*100}
+                                  status={'active'}
+                                  format={() => text}
+                                  strokeColor={getColor((text/999)*100)}
+        />,
+        sorter: {
+          compare: (a, b) => a.RAM - b.RAM
+        },
+      },
+      {
+        title: 'Storage (MB)',
+        dataIndex: 'Storage',
+        key: 'Storage',
+        render: text => <Progress percent={(text/999)*100}
+                                  status={'active'}
+                                  format={() => text}
+                                  strokeColor={getColor((text/999)*100)}
+        />,
+        sorter: {
+          compare: (a, b) => a.Storage - b.Storage
+        },
+      },
+    ];
+
+    const data = [];
+
+    pods.forEach(po => {
+      data.push(
+        {
+          key: po.metadata.name,
+          Name: po.metadata.name,
+          Status: po.status.phase,
+          CPU: this.getUsedPODCPU(),
+          RAM: this.getUsedPODRAM(),
+          Storage: this.getUsedPODStorage()
+        },
+      )
+    })
+
+    return(
+      <Table size={'small'} columns={column} dataSource={data}
+             pagination={{ size: 'small', position: ['bottomCenter'], pageSize: 11 }} />
+    )
+  }
+
+  /**
+   * Get and show the used resources for a connection
+   * @role: can be home or foreign
+   */
+  getUsedResources(role) {
+    const totalCPU = this.getUsedTotalCPU(role);
+    const totalRAM = this.getUsedTotalRAM(role);
+    const totalStorage = this.getUsedTotalStorage(role);
+
+    return(
+      <div>
+        <div style={{marginTop: 10}}>
+          <Row>
+            <Col flex={1}>
+              <Card title={'Resources Used'} style={{marginRight: 20}}>
+                <Row gutter={[20, 20]} align={'center'} justify={'center'}>
+                  <Col>
+                    <Row justify={'center'}>
+                      <Typography.Text strong>CPU</Typography.Text>
+                    </Row>
+                    <Row justify={'center'}>
+                      <Progress type={'dashboard'} percent={totalCPU}
+                                strokeColor={getColor(totalCPU)}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+                <Row gutter={[20, 20]} align={'center'} justify={'center'}>
+                  <Col>
+                    <Row justify={'center'}>
+                      <Typography.Text strong>RAM</Typography.Text>
+                    </Row>
+                    <Row justify={'center'}>
+                      <Progress type={'dashboard'} percent={totalRAM}
+                                strokeColor={getColor(totalRAM)}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+                <Row gutter={[20, 20]} align={'center'} justify={'center'}>
+                  <Col>
+                    <Row justify={'center'}>
+                      <Typography.Text strong>Storage</Typography.Text>
+                    </Row>
+                    <Row justify={'center'}>
+                      <Progress type={'dashboard'} percent={totalStorage}
+                                strokeColor={getColor(totalStorage)}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+              </Card>
+            </Col>
+            <Col flex={23}>
+              <Card title={ role === 'foreign' ? 'Outgoing PODs' : 'Incoming PODs'}
+                    bodyStyle={{padding: 0}}
+              >
+                { role === 'foreign' ? this.PODtoTable(this.props._this.state.outgoingPods) : this.PODtoTable(this.props._this.state.incomingPods) }
+              </Card>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    )
+  }
+  
+  render(){
+    return(
+      <Modal
+        title={'Details'}
+        width={'50vw'}
+        visible={this.props._this.state.showDetails}
+        onCancel={() => {this.props._this.setState({showDetails: false}); this.setState({currentTab: '1'})}}
+        bodyStyle={{paddingTop: 0}}
+        footer={null}
+        destroyOnClose
+      >
+        <Tabs activeKey={this.state.currentTab} onChange={key => this.setState({currentTab: key})}>
+          <Tabs.TabPane tab={<span><InfoCircleOutlined />General</span>} key={'1'}>
+            <div style={{minHeight: '40vh'}}>
+              <Space direction={'vertical'}>
+                <div>
+                  { this.props.client ? (
+                    <Badge text={
+                      <>
+                        Using
+                        <> </>
+                        <Tag style={{marginRight: 3}}>{this.props.foreignCluster.spec.clusterID}</Tag>
+                        's resources.
+                      </>
+                    }
+                           status={'processing'}
+                    />
+                  ) : null }
+                </div>
+                <div>
+                  { this.props.server ? (
+                    <Badge text={
+                      <>
+                        <Tag style={{marginRight: 3}}>{this.props.foreignCluster.spec.clusterID}</Tag>
+                        <> </>
+                        is using your resources.
+                      </>
+                    }
+                           status={'processing'}
+                    />
+                  ) : null }
+                </div>
+              </Space>
+            </div>
+          </Tabs.TabPane>
+          { this.props.server ? (
+            <Tabs.TabPane tab={<span><HomeOutlined />Home</span>} key={'2'}>
+              {this.getUsedResources('home')}
+            </Tabs.TabPane>
+          ) : null }
+          { this.props.client ? (
+            <Tabs.TabPane tab={<span><GlobalOutlined />Foreign</span>} key={'3'}>
+              {this.getUsedResources('foreign')}
+            </Tabs.TabPane>
+          ) : null }
+        </Tabs>
+      </Modal>
+    )
+  }
+}
+
+export default ConnectionDetails;

--- a/src/home/HomeUtils.js
+++ b/src/home/HomeUtils.js
@@ -1,4 +1,6 @@
-import { notification } from 'antd';
+import { Space, notification, Button, Table,
+Progress, Input, Tag } from 'antd';
+import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
 import { APP_NAME } from '../constants';
 import React from 'react';
 

--- a/src/home/ListAvailable.js
+++ b/src/home/ListAvailable.js
@@ -33,7 +33,8 @@ class ListAvailable extends Component {
     promise
       .then(() => {
         this.setState({
-          isLoading: false
+          isLoading: false,
+          showAddPeer: false
         });
         notification.success({
           message: APP_NAME,

--- a/src/services/ApiManager.js
+++ b/src/services/ApiManager.js
@@ -21,6 +21,7 @@ export default class ApiManager {
     this.kcc = new Config(window.APISERVER_URL, user.id_token, user.token_type);
     this.apiExt = this.kcc.makeApiClient(ApiextensionsV1beta1Api);
     this.apiCRD = this.kcc.makeApiClient(CustomObjectsApi);
+    this.apiCore = this.kcc.makeApiClient(CoreV1Api);
     this.CRDs = [];
     this.customViews = [];
     this.watchers = [];
@@ -199,7 +200,7 @@ export default class ApiManager {
    * @returns a promise
    */
   createCustomResource(group, version, namespace, plural, item) {
-    if(namespace !== ''){
+    if(namespace !== '' && namespace){
       return this.apiCRD.createNamespacedCustomObject(
         group,
         version,
@@ -567,6 +568,16 @@ export default class ApiManager {
     this.CVArrayCallback.forEach(func => {
       func(customViews);
     })
+  }
+
+  /** gets all namespaces with label */
+  getNamespaces(label){
+    return this.apiCore.listNamespace(null, null, null, null, label)
+  }
+
+  /** gets all the pods with namespace (if specified) */
+  getPODs(namespace){
+    return this.apiCore.listPodForAllNamespaces(null, namespace ? 'metadata.namespace=' + namespace : null);
   }
 
 }

--- a/src/services/__mocks__/ApiManager.js
+++ b/src/services/__mocks__/ApiManager.js
@@ -425,4 +425,13 @@ export default class ApiManager {
     })
   }
 
+  getNamespaces(label){
+    return Promise.resolve({body: { items: [{ metadata: { name: 'test' }}]}});
+  }
+
+  /** gets all the pods */
+  getPODs(namespace){
+    return fetch('http://localhost:3001/pod/').then(res => res.json());
+  }
+
 }

--- a/test/AvailableList.test.js
+++ b/test/AvailableList.test.js
@@ -14,6 +14,7 @@ import SDMockResponse from '../__mocks__/searchdomain.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -67,6 +68,8 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }

--- a/test/AvailablePeer.test.js
+++ b/test/AvailablePeer.test.js
@@ -20,6 +20,7 @@ import AdvMockResponseNoStatus from '../__mocks__/advertisement_noStatus.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -72,6 +73,8 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }

--- a/test/CR.test.js
+++ b/test/CR.test.js
@@ -159,6 +159,6 @@ describe('CR', () => {
     userEvent.click(yes);
 
     expect(await screen.findByText(/404/i)).toBeInTheDocument();
-  })
+  }, 30000)
 
 })

--- a/test/ConnectedList.test.js
+++ b/test/ConnectedList.test.js
@@ -13,6 +13,7 @@ import AdvMockResponse from '../__mocks__/advertisement.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -54,6 +55,8 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -18,6 +18,7 @@ import AdvMockResponseNoStatus from '../__mocks__/advertisement_noStatus.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -59,6 +60,8 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }

--- a/test/ConnectionDetails.test.js
+++ b/test/ConnectionDetails.test.js
@@ -1,0 +1,198 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { render, screen } from '@testing-library/react';
+import ViewMockResponse from '../__mocks__/views.json';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import Home from '../src/home/Home';
+import FCMockResponse from '../__mocks__/foreigncluster.json';
+import FCMockResponseNoIn from '../__mocks__/foreigncluster_noIncoming.json';
+import FCMockResponseNoOut from '../__mocks__/foreigncluster_noOutgoing.json';
+import PRMockResponse from '../__mocks__/peeringrequest.json';
+import AdvMockResponse from '../__mocks__/advertisement.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import CRDmockResponse from '../__mocks__/crd_fetch.json';
+import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
+import userEvent from '@testing-library/user-event';
+
+fetchMock.enableMocks();
+
+let api;
+
+async function setup() {
+  api = new ApiManager();
+  api.getCRDs().then(async () => {
+    render(
+      <MemoryRouter>
+        <Home api={api} />
+      </MemoryRouter>
+    )
+  });
+}
+
+function mocks(advertisement, foreignCluster, peeringRequest, error, podsError) {
+  fetch.mockResponse((req) => {
+    if (req.url === 'http://localhost:3001/customresourcedefinition') {
+      return Promise.resolve(new Response(JSON.stringify(CRDmockResponse)))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/views') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/foreignclusters') {
+      if(req.method === 'GET')
+        return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+      else{
+        if(!error){
+          foreignCluster = foreignCluster.items[0];
+          foreignCluster.metadata.resourceVersion++;
+          foreignCluster.spec.join = false;
+          return Promise.resolve(new Response(JSON.stringify({ body: foreignCluster })));
+        } else {
+          return Promise.reject(Error409.body);
+        }
+      }
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/advertisements') {
+      return Promise.resolve(new Response(JSON.stringify({ body: advertisement })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/peeringrequests') {
+      return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
+    } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      if(podsError)
+        return Promise.reject(Error409.body);
+      else
+        return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    }
+  })
+}
+
+async function OKCheck() {
+  await setup();
+
+  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
+
+  userEvent.click(screen.getByLabelText('ellipsis'));
+
+  userEvent.click(await screen.findByLabelText('snippets'));
+
+  expect(await screen.findByText('General')).toBeInTheDocument();
+
+  userEvent.click(await screen.findByText('Home'));
+
+  expect(await screen.findByText(/POD/i)).toBeInTheDocument();
+}
+
+async function sort(){
+  expect(screen.getAllByText(/hello/i)).toHaveLength(2);
+
+  userEvent.click(screen.getAllByLabelText('search')[0]);
+
+  const search = await screen.findByRole('textbox');
+
+  await userEvent.type(search, 'c7qzv');
+}
+
+describe('ConnectionDetails', () => {
+
+  /*test('Error on getting pods', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, null, true);
+
+    await OKCheck();
+
+    expect(await screen.findByText('Could not get pods')).toBeInTheDocument();
+  })*/
+
+  test('Detail button works (out and in)', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+  })
+
+  test('Detail button works (only out)', async () => {
+    mocks(AdvMockResponse, FCMockResponseNoIn, PRMockResponse);
+
+    await setup();
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
+
+    userEvent.click(screen.getByLabelText('ellipsis'));
+
+    userEvent.click(await screen.findByLabelText('snippets'));
+
+    expect(await screen.findByText('General')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByText('Foreign'));
+
+    expect(await screen.findByText(/POD/i)).toBeInTheDocument();
+  })
+
+  test('Detail button works (only in)', async () => {
+    mocks(AdvMockResponse, FCMockResponseNoOut, PRMockResponse);
+
+    await OKCheck();
+  })
+
+  test('Search pods works (click)', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    await sort();
+
+    const searchButton = await screen.findByText('Search');
+
+    userEvent.click(searchButton);
+
+    expect(screen.getAllByText(/hello/i)).toHaveLength(1);
+  })
+
+  test('Search pods works (enter)', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    await sort();
+
+    await userEvent.type(screen.getByRole('textbox'), '{enter}');
+
+    expect(screen.getAllByText(/hello/i)).toHaveLength(1);
+  })
+
+  test('Search reset pods works', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    await sort();
+
+    const resetButton = await screen.findByText('Reset');
+
+    userEvent.click(resetButton);
+
+    expect(screen.getAllByText(/hello/i)).toHaveLength(2);
+  })
+
+  test('Sorting pods works and close modal', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    userEvent.click(screen.getByText('CPU (%)'));
+
+    userEvent.click(screen.getByText('RAM (MB)'));
+
+    userEvent.click(screen.getByText('Storage (MB)'));
+
+    let close = await screen.findAllByLabelText('close');
+
+    userEvent.click(close[2]);
+
+    setTimeout(() => {
+      expect(screen.queryByText('Foreign Cluster')).not.toBeInTheDocument();
+    }, 1500);
+
+    userEvent.click(await screen.findByLabelText('plus'));
+  }, 30000)
+})

--- a/test/PeerProperties.test.js
+++ b/test/PeerProperties.test.js
@@ -15,6 +15,7 @@ import SDMockResponse from '../__mocks__/searchdomain.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -68,6 +69,8 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }

--- a/test/RTLUtils.js
+++ b/test/RTLUtils.js
@@ -18,6 +18,7 @@ import FCMockNew from '../__mocks__/foreigncluster_new.json';
 import PRMockResponse from '../__mocks__/peeringrequest.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import ConfigMockResponseUpdated from '../__mocks__/configs_updated.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 import Error409 from '../__mocks__/409.json';
 import Error404 from '../__mocks__/404.json';
 
@@ -38,6 +39,8 @@ export function generalHomeGET(url) {
     return Promise.resolve(new Response(JSON.stringify({body: PRMockResponse})));
   } else if (url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
     return Promise.resolve(new Response(JSON.stringify({body: ConfigMockResponse})));
+  } else if (url === 'http://localhost:3001/pod/') {
+    return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
   }
 }
 
@@ -104,6 +107,8 @@ export function mockCRDAndViewsExtended(error, method, crd, view) {
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return responseManager(req, error, method, crd, 'clusterconfigs',
         ConfigMockResponse, null, ConfigMockResponseUpdated);
+    } else if (req.url === 'http://localhost:3001/pod/') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     }
   })
 }


### PR DESCRIPTION
# Description

This PR introduces a view of the detail for a given peer connection.

The details showed are the following:

- General tab: rather empty for now, meant to show some general information of the connection (for now, only shows the direction of the connection)
- Home tab: shows the **foreign cluster**'s consumption of resources in the **home cluster**, as well as a list of the pods that the **foreign cluster** has offloaded to the **home cluster**. It also show the total consumption of these pods relative to the consumption limit established. 
- Foreign tab: same as the Home tab, but the direction of the consumption relationship is inverted.

If the connection is not mutual, one of the two tabs are not showed (e.g. if only I can use your resources, but you are not allowed to use mine, there will be no Home tab, because you are not offloading pods to my cluster) .