### PR TITLE
LIQO home view - connection (peering) status and metrics

### DIFF
--- a/__mocks__/advertisement.json
+++ b/__mocks__/advertisement.json
@@ -223,7 +223,7 @@
         "resourceQuota": {
           "hard": {
             "cpu": "2145m",
-            "memory": "5965988659",
+            "memory": "5665988659",
             "pods": "33"
           }
         }
@@ -238,7 +238,7 @@
         },
         "vkCreated": true,
         "vkReference": {
-          "name": "vk-test"
+          "name": "liqo-test"
         }
       }
     }

--- a/__mocks__/nodes.json
+++ b/__mocks__/nodes.json
@@ -1,0 +1,84 @@
+{
+  "kind": "NodeList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/nodes",
+    "resourceVersion": "000000"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "liqo1-control-plane",
+        "selfLink": "/api/v1/nodes/liqo1-control-plane",
+        "resourceVersion": "000000",
+        "labels": {
+          "liqonet.liqo.io/gateway": "true"
+        },
+        "annotations": {
+          "kubeadm.alpha.kubernetes.io/cri-socket": "/run/containerd/containerd.sock",
+          "node.alpha.kubernetes.io/ttl": "0",
+          "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        }
+      },
+      "spec": {
+        "podCIDR": "10.244.0.0/24",
+        "podCIDRs": [
+          "10.244.0.0/24"
+        ]
+      },
+      "status": {
+        "capacity": {
+          "cpu": "8",
+          "ephemeral-storage": "263174212Ki",
+          "hugepages-2Mi": "0",
+          "memory": "19615096Ki",
+          "pods": "110"
+        },
+        "allocatable": {
+          "cpu": "8",
+          "ephemeral-storage": "263174212Ki",
+          "hugepages-2Mi": "0",
+          "memory": "19615096Ki",
+          "pods": "110"
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "vk-test",
+        "selfLink": "/api/v1/nodes/vk-test",
+        "resourceVersion": "000000",
+        "labels": {
+          "type": "virtual-node"
+        },
+        "annotations": {
+          "kubeadm.alpha.kubernetes.io/cri-socket": "/run/containerd/containerd.sock",
+          "node.alpha.kubernetes.io/ttl": "0",
+          "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+        }
+      },
+      "spec": {
+        "podCIDR": "10.244.0.0/24",
+        "podCIDRs": [
+          "10.244.0.0/24"
+        ]
+      },
+      "status": {
+        "capacity": {
+          "cpu": "8",
+          "ephemeral-storage": "263174212Ki",
+          "hugepages-2Mi": "0",
+          "memory": "19615096Ki",
+          "pods": "110"
+        },
+        "allocatable": {
+          "cpu": "8",
+          "ephemeral-storage": "263174212Ki",
+          "hugepages-2Mi": "0",
+          "memory": "19615096Ki",
+          "pods": "110"
+        }
+      }
+    }
+  ]
+}

--- a/__mocks__/nodes_metrics.json
+++ b/__mocks__/nodes_metrics.json
@@ -1,0 +1,31 @@
+{
+  "kind": "NodeMetricsList",
+  "apiVersion": "metrics.k8s.io/v1beta1",
+  "metadata": {
+    "selfLink": "/apis/metrics.k8s.io/v1beta1/nodes"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "liqo1-control-plane",
+        "selfLink": "/apis/metrics.k8s.io/v1beta1/nodes/liqo1-control-plane"
+      },
+      "window": "30s",
+      "usage": {
+        "cpu": "385786574n",
+        "memory": "1173984Ki"
+      }
+    },
+    {
+      "metadata": {
+        "name": "vk-test",
+        "selfLink": "/apis/metrics.k8s.io/v1beta1/nodes/vk-test"
+      },
+      "window": "30s",
+      "usage": {
+        "cpu": "385786574n",
+        "memory": "1173984Ki"
+      }
+    }
+  ]
+}

--- a/__mocks__/pods.json
+++ b/__mocks__/pods.json
@@ -74,7 +74,7 @@
         "dnsPolicy": "ClusterFirst",
         "serviceAccountName": "default",
         "serviceAccount": "default",
-        "nodeName": "vk-test",
+        "nodeName": "liqo-test",
         "securityContext": {
 
         },
@@ -119,7 +119,7 @@
         },
         "annotations": {
           "home_creationTimestamp": "2020-08-18 14:48:22 +0000 UTC",
-          "home_nodename": "vk-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
+          "home_nodename": "liqo-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
           "home_resourceVersion": "13731",
           "home_uuid": "e1dce48a-60b0-4368-8d83-d2d2b9589cd1"
         }
@@ -230,7 +230,7 @@
         },
         "annotations": {
           "home_creationTimestamp": "2020-08-18 14:48:22 +0000 UTC",
-          "home_nodename": "vk-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
+          "home_nodename": "liqo-4317f039-e7b8-40d2-ae20-18d1c47e69f0",
           "home_resourceVersion": "13728",
           "home_uuid": "16bc4174-b9d1-4fff-a994-bcba1aabfd24"
         }

--- a/__mocks__/pods_metrics.json
+++ b/__mocks__/pods_metrics.json
@@ -1,0 +1,55 @@
+{
+  "podMetrics": [
+    {
+      "kind": "PodMetrics",
+      "apiVersion": "metrics.k8s.io/v1beta1",
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-x66v9",
+        "namespace": "test-66b8128a-3fdf-4d78-bd8f-40b7ef860a8b"
+      },
+      "containers": [
+        {
+          "name": "hello-world",
+          "usage": {
+            "cpu": "1",
+            "memory": "5065970000Ki"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "PodMetrics",
+      "apiVersion": "metrics.k8s.io/v1beta1",
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-c7qzv",
+        "namespace": "test-66b8128a-3fdf-4d78-bd8f-40b7ef860a8b"
+      },
+      "containers": [
+        {
+          "name": "hello-world",
+          "usage": {
+            "cpu": "0",
+            "memory": "7624Ki"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "PodMetrics",
+      "apiVersion": "metrics.k8s.io/v1beta1",
+      "metadata": {
+        "name": "hello-world-deployment-6756549f5-c7sx8",
+        "namespace": "test-66b8128a-3fdf-4d78-bd8f-40b7ef860a8b"
+      },
+      "containers": [
+        {
+          "name": "hello-world",
+          "usage": {
+            "cpu": "3",
+            "memory": "7624Ki"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/home/ListConnected.js
+++ b/src/home/ListConnected.js
@@ -33,10 +33,10 @@ class ListConnected extends Component {
                 this.setState({outgoingPods: this.state.outgoingPods});
               })
             })
+            .catch(error => {
+              console.log(error);
+            })
         })
-      })
-      .catch(error => {
-        console.log(error)
       })
   }
 

--- a/src/services/ApiManager.js
+++ b/src/services/ApiManager.js
@@ -18,6 +18,7 @@ export default class ApiManager {
     if (window.APISERVER_URL === undefined) {
       window.APISERVER_URL = APISERVER_URL;
     }
+    this.user = user;
     this.kcc = new Config(window.APISERVER_URL, user.id_token, user.token_type);
     this.apiExt = this.kcc.makeApiClient(ApiextensionsV1beta1Api);
     this.apiCRD = this.kcc.makeApiClient(CustomObjectsApi);
@@ -578,6 +579,43 @@ export default class ApiManager {
   /** gets all the pods with namespace (if specified) */
   getPODs(namespace){
     return this.apiCore.listPodForAllNamespaces(null, namespace ? 'metadata.namespace=' + namespace : null);
+  }
+
+  /** gets the list of all the nodes in cluster */
+  getNodes(){
+    return this.apiCore.listNode();
+  }
+
+  /** gets the metrics of pods for a specific namespace */
+  getMetricsPOD(namespace, name){
+    let url = window.APISERVER_URL + '/apis/metrics.k8s.io/v1beta1/namespaces/' + namespace + '/pods/' + name;
+
+    let headers = new Headers();
+    headers.append("Authorization", "Bearer " + this.user.id_token);
+
+    let requestOptions = {
+      method: 'GET',
+      headers: headers,
+      redirect: 'follow'
+    };
+
+    return fetch(url, requestOptions).then(res => res.json());
+  }
+
+  /** gets the metrics of all the nodes on the cluster */
+  getMetricsNodes(){
+    let url = window.APISERVER_URL + '/apis/metrics.k8s.io/v1beta1/nodes'
+
+    let headers = new Headers();
+    headers.append("Authorization", "Bearer " + this.user.id_token);
+
+    let requestOptions = {
+      method: 'GET',
+      headers: headers,
+      redirect: 'follow'
+    };
+
+    return fetch(url, requestOptions).then(res => res.json());
   }
 
 }

--- a/src/services/__mocks__/ApiManager.js
+++ b/src/services/__mocks__/ApiManager.js
@@ -431,7 +431,19 @@ export default class ApiManager {
 
   /** gets all the pods */
   getPODs(namespace){
-    return fetch('http://localhost:3001/pod/').then(res => res.json());
+    return fetch('http://localhost:3001/pod').then(res => res.json());
+  }
+
+  getNodes(){
+    return fetch('http://localhost:3001/nodes').then(res => res.json());
+  }
+
+  getMetricsPOD(namespace, name){
+    return fetch('http://localhost:3001/metrics/pods/' + name).then(res => res.json());
+  }
+
+  getMetricsNodes(){
+    return fetch('http://localhost:3001/metrics/nodes').then(res => res.json());
   }
 
 }

--- a/test/AppHeader.test.js
+++ b/test/AppHeader.test.js
@@ -50,7 +50,7 @@ describe('Header', () => {
     await loginTest();
 
     expect(await screen.findByLabelText('notification')).toBeInTheDocument();
-    expect(await screen.findByLabelText('question-circle')).toBeInTheDocument();
+    expect(await screen.findAllByLabelText('question-circle')).toHaveLength(1);
     expect(await screen.findByLabelText('logout')).toBeInTheDocument();
     const CRDInput = await screen.findAllByRole('combobox');
     expect(CRDInput[0]).toHaveAttribute('placeholder', 'input CRD');

--- a/test/AvailableList.test.js
+++ b/test/AvailableList.test.js
@@ -15,6 +15,8 @@ import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
 import PodsMockResponse from '../__mocks__/pods.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
 
 fetchMock.enableMocks();
 
@@ -68,8 +70,12 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
-    } else if (req.url === 'http://localhost:3001/pod/') {
+    } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else if (req.url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (req.url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
     }
   })
 }

--- a/test/AvailablePeer.test.js
+++ b/test/AvailablePeer.test.js
@@ -10,17 +10,18 @@ import Home from '../src/home/Home';
 import FCMockResponse from '../__mocks__/foreigncluster_noJoin.json';
 import FCMockResponseJoin from '../__mocks__/foreigncluster.json';
 import FCMockResponseNoIn from '../__mocks__/foreigncluster_noIncoming.json';
-import FCMockResponseNoOut from '../__mocks__/foreigncluster_noOutgoing.json';
 import PRMockResponse from '../__mocks__/peeringrequest.json';
 import AdvMockResponse from '../__mocks__/advertisement.json';
 import SDMockResponse from '../__mocks__/searchdomain.json';
 import AdvMockResponseRefused from '../__mocks__/advertisement_refused.json';
 import AdvMockResponseNotAccepted from '../__mocks__/advertisement_notAccepted.json';
-import AdvMockResponseNoStatus from '../__mocks__/advertisement_noStatus.json';
 import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
 import PodsMockResponse from '../__mocks__/pods.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
+import { metricsPODs } from './RTLUtils';
 
 fetchMock.enableMocks();
 
@@ -73,8 +74,14 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
-    } else if (req.url === 'http://localhost:3001/pod/') {
+    } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else if (req.url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (req.url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+    } else {
+      return metricsPODs(req);
     }
   })
 }
@@ -104,6 +111,14 @@ async function addPeer() {
 describe('AvailablePeer', () => {
   test('List of available peers shows', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
+
+    await OKCheck();
+
+    userEvent.click(screen.getByLabelText('dropdown-available'));
+  })
+
+  test('List of available peers shows (with refused adv)', async () => {
+    mocks(AdvMockResponseRefused, FCMockResponseJoin, {items: []});
 
     await OKCheck();
 
@@ -158,8 +173,6 @@ describe('AvailablePeer', () => {
     await OKCheck();
 
     userEvent.click(screen.getByLabelText('ellipsis'));
-
-    screen.debug(await screen.findByLabelText('link'));
 
     userEvent.click(await screen.findByLabelText('link'));
 

--- a/test/CRD.test.js
+++ b/test/CRD.test.js
@@ -381,7 +381,7 @@ describe('CRD', () => {
     userEvent.click(no);
 
     api = null;
-  })
+  }, 30000)
 
   test('CRD template error', async () => {
     await setup_only_CRD(true, true);

--- a/test/ConfigView.test.js
+++ b/test/ConfigView.test.js
@@ -3,7 +3,7 @@ import CRDmockResponse from '../__mocks__/crd_fetch.json';
 import ClusterConfigMockResponse from '../__mocks__/configs.json';
 import { render, screen } from '@testing-library/react';
 import Error409 from '../__mocks__/409.json';
-import { loginTest } from './RTLUtils';
+import { loginTest, metricsPODs } from './RTLUtils';
 import userEvent from '@testing-library/user-event';
 import FCMockResponse from '../__mocks__/foreigncluster.json';
 import AdvMockResponse from '../__mocks__/advertisement.json';
@@ -12,6 +12,10 @@ import ApiManager from '../src/services/__mocks__/ApiManager';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import ConfigView from '../src/views/ConfigView';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 function mocks(error, get){
   fetch.mockResponse(req => {
@@ -42,6 +46,14 @@ function mocks(error, get){
           return Promise.resolve(new Response(JSON.stringify({ body: ClusterConfigMockResponseMod })))
         }
       }
+    } else if (req.url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (req.url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+    } else if (req.url === 'http://localhost:3001/pod') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else {
+      return metricsPODs(req);
     }
   })
 }

--- a/test/DesignEditorCRD.test.js
+++ b/test/DesignEditorCRD.test.js
@@ -128,7 +128,7 @@ describe('DesignEditorCRD', () => {
     await fillFields(true);
 
     expect(await screen.findByText(/Please/i));
-  })
+  }, 30000)
 
   test('Definition of a new template works', async () => {
     await setup_resource();
@@ -150,7 +150,6 @@ describe('DesignEditorCRD', () => {
     expect(await screen.findByText('CRD modified')).toBeInTheDocument();
 
     await userEvent.click(await screen.findByText('test-1'));
-
   }, 30000)
 
   test('Default template overrides old template', async () => {

--- a/test/FormViewer.test.js
+++ b/test/FormViewer.test.js
@@ -13,7 +13,7 @@ import Error409 from '../__mocks__/409.json';
 
 fetchMock.enableMocks();
 
-function mockFetch() {
+function mockFetch(error) {
   fetch.mockResponse(req => {
     if (req.url === 'http://localhost:3001/customresourcedefinition') {
       return Promise.resolve(new Response(JSON.stringify(CRDmockResponse)))

--- a/test/Home.test.js
+++ b/test/Home.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
-import { mockCRDAndViewsExtended } from './RTLUtils';
+import { metricsPODs, mockCRDAndViewsExtended } from './RTLUtils';
 import { render, screen } from '@testing-library/react';
 import ApiManager from '../src/services/__mocks__/ApiManager';
 import { MemoryRouter } from 'react-router-dom';
@@ -11,6 +11,10 @@ import FCMockResponse from '../__mocks__/foreigncluster.json';
 import AdvMockResponse from '../__mocks__/advertisement.json';
 import PRMockResponse from '../__mocks__/peeringrequest.json';
 import Error404 from '../__mocks__/404.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import Error409 from '../__mocks__/409.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
+import PodsMockResponse from '../__mocks__/pods.json';
 
 fetchMock.enableMocks();
 
@@ -39,6 +43,14 @@ function mocks(){
       return Promise.resolve(new Response(JSON.stringify({body: PRMockResponse})));
     } else if (url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.reject(Error404.body);
+    } else if (url === 'http://localhost:3001/nodes') {
+        return Promise.resolve(new Response(JSON.stringify(NodesMockResponse)));
+    } else if (url === 'http://localhost:3001/metrics/nodes') {
+        return Promise.resolve(new Response(JSON.stringify({body: NodesMetricsMockResponse})));
+    } else if (url === 'http://localhost:3001/pod') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else {
+      return metricsPODs({req: url});
     }
   })
 }

--- a/test/PeerProperties.test.js
+++ b/test/PeerProperties.test.js
@@ -16,6 +16,9 @@ import ConfigMockResponse from '../__mocks__/configs.json';
 import CRDmockEmpty from '../__mocks__/crd_fetch.json';
 import Error409 from '../__mocks__/409.json';
 import PodsMockResponse from '../__mocks__/pods.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
+import { metricsPODs } from './RTLUtils';
 
 fetchMock.enableMocks();
 
@@ -69,8 +72,14 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
       return Promise.resolve(new Response(JSON.stringify({ body: peeringRequest })));
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return Promise.resolve(new Response(JSON.stringify({ body: ConfigMockResponse })));
-    } else if (req.url === 'http://localhost:3001/pod/') {
+    } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else if (req.url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (req.url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+    } else {
+      return metricsPODs(req);
     }
   })
 }

--- a/test/RTLUtils.js
+++ b/test/RTLUtils.js
@@ -21,6 +21,9 @@ import ConfigMockResponseUpdated from '../__mocks__/configs_updated.json';
 import PodsMockResponse from '../__mocks__/pods.json';
 import Error409 from '../__mocks__/409.json';
 import Error404 from '../__mocks__/404.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json'
+import PodsMetricsMockResponse from '../__mocks__/pods_metrics.json';
 
 export function setup_login() {
   return render(
@@ -28,6 +31,18 @@ export function setup_login() {
       <App />
     </MemoryRouter>
   );
+}
+
+export function metricsPODs(req, error){
+  if(error){
+    return Promise.reject(Error409.body);
+  } else if (req.url === 'http://localhost:3001/metrics/pods/hello-world-deployment-6756549f5-x66v9') {
+    return Promise.resolve(new Response(JSON.stringify(PodsMetricsMockResponse.podMetrics[0])));
+  } else if (req.url === 'http://localhost:3001/metrics/pods/hello-world-deployment-6756549f5-c7qzv') {
+    return Promise.resolve(new Response(JSON.stringify(PodsMetricsMockResponse.podMetrics[1])));
+  } else if (req.url === 'http://localhost:3001/metrics/pods/hello-world-deployment-6756549f5-c7sx8') {
+    return Promise.resolve(new Response(JSON.stringify(PodsMetricsMockResponse.podMetrics[2])));
+  }
 }
 
 export function generalHomeGET(url) {
@@ -39,8 +54,14 @@ export function generalHomeGET(url) {
     return Promise.resolve(new Response(JSON.stringify({body: PRMockResponse})));
   } else if (url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
     return Promise.resolve(new Response(JSON.stringify({body: ConfigMockResponse})));
-  } else if (url === 'http://localhost:3001/pod/') {
+  } else if (url === 'http://localhost:3001/pod') {
     return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+  } else if (url === 'http://localhost:3001/nodes') {
+    return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+  } else if (url === 'http://localhost:3001/metrics/nodes') {
+    return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+  } else {
+    return metricsPODs({url : url});
   }
 }
 
@@ -107,8 +128,14 @@ export function mockCRDAndViewsExtended(error, method, crd, view) {
     } else if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
       return responseManager(req, error, method, crd, 'clusterconfigs',
         ConfigMockResponse, null, ConfigMockResponseUpdated);
-    } else if (req.url === 'http://localhost:3001/pod/') {
+    } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else if (req.url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (req.url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+    } else {
+      return metricsPODs(req);
     }
   })
 }

--- a/test/SideBar.test.js
+++ b/test/SideBar.test.js
@@ -13,7 +13,7 @@ describe('Sidebar', () => {
     mockCRDAndViewsExtended();
     await loginTest();
 
-    expect(await screen.findByText(/Home/i)).toBeInTheDocument();
+    expect(await screen.findAllByText(/Home/i)).toHaveLength(1);
 
     expect(await screen.findByText(/custom/i)).toBeInTheDocument();
 


### PR DESCRIPTION
## Description

This PR adds the real-time monitoring of a single connection (peering), visible directly in the general view (a circle around the home cluster and/or the foreign home, depending if there is resource consumption, that shows the % of how much memory is being consumed) or more specific in the details view.

In details:
- The statistic is based on how many resources (CPU/RAM) are consumed by the sum of the pods offloaded in the other cluster, in relationship to how much resource sharing is established (e.g. I am connected with the foreign cluster X. In the advertisement of foreign cluster X it is established that it will share with me 5GB of RAM, and the sum of the consumed RAM of my pods offloaded to the foreign cluster is 1GB, that means I am using 20% of the available RAM in the foreign cluster X)
- The statistic of every pod in the pod table in the details view is the real-time consumption of that pod in relationship to how much is its requested resource (e.g. if the pod request is 100Mi of RAM and it is using 20Mi, that means that in the table, under the tab RAM it will show a 20% filled progress bar). Also hovering with mouse over the resource (CPU/RAM) will show the consumption in Mi.
- The pods metrics are fetched and updated every 30 seconds.