### PR TITLE
Update cluster role binding

### DIFF
--- a/kubernetes/config/dashboard-sa-crb.yaml
+++ b/kubernetes/config/dashboard-sa-crb.yaml
@@ -11,7 +11,6 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  namespace: liqo-dashboard
   name: liqodash-admin-sa
   labels:
     app: liqo-dashboard
@@ -22,4 +21,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: liqodash-admin-sa
-  namespace: liqo-dashboard
+  namespace: liqo


### PR DESCRIPTION
## Description
This PR updates the cluster role binding configuration deleting the definition of a namespace. Without that namespace the secret created can be used to access the entire cluster (previously that secret would have granted permission to access only the defined namespace)