### PR TITLE
LIQO home view - pods metrics when there is no metrics server available

### DIFF
--- a/__mocks__/pods.json
+++ b/__mocks__/pods.json
@@ -150,8 +150,8 @@
                 "memory": "256Mi"
               },
               "requests": {
-                "cpu": "80m",
-                "memory": "128Mi"
+                "cpu": "80000k",
+                "memory": "0.128Gi"
               }
             },
             "volumeMounts": [
@@ -261,7 +261,7 @@
                 "memory": "256Mi"
               },
               "requests": {
-                "cpu": "80m",
+                "cpu": "0.08g",
                 "memory": "128Mi"
               }
             },

--- a/__mocks__/pods_metrics.json
+++ b/__mocks__/pods_metrics.json
@@ -12,7 +12,7 @@
           "name": "hello-world",
           "usage": {
             "cpu": "1",
-            "memory": "5065970000Ki"
+            "memory": "5065970Ki"
           }
         }
       ]
@@ -28,7 +28,7 @@
         {
           "name": "hello-world",
           "usage": {
-            "cpu": "0",
+            "cpu": "1191721438n",
             "memory": "7624Ki"
           }
         }

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -9,6 +9,8 @@ import GlobalOutlined from '@ant-design/icons/lib/icons/GlobalOutlined';
 import { getColor } from './HomeUtils';
 import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
 
+const n = Math.pow(10, 6);
+
 class ConnectionDetails extends Component {
   constructor(props) {
     super(props);
@@ -129,7 +131,7 @@ class ConnectionDetails extends Component {
         key: 'RAM',
         render: (text, record) => {
           let podRAMmb = (role && this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name})) ?
-            this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name}).RAMmi : 0;
+            this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name}).RAMmi / n : 0;
 
           return(
             <Tooltip title={podRAMmb + 'Mi'}>
@@ -159,8 +161,6 @@ class ConnectionDetails extends Component {
       const pod = role ?
         this.props.incomingPodsPercentage.find(pod => {return po.metadata.name === pod.name}) :
         this.props.outgoingPodsPercentage.find(pod => {return po.metadata.name === pod.name})
-
-      //console.log(pod, this.state.incomingPodsPercentage, po)
 
       data.push(
         {

--- a/src/home/HomeUtils.js
+++ b/src/home/HomeUtils.js
@@ -95,3 +95,30 @@ export function addZero(i) {
   }
   return i;
 }
+
+export function convertRAM(string) {
+  let unit = string.slice(-2);
+
+  if(unit === 'Ki'){
+    return parseFloat(string) * Math.pow(10, 3);
+  } else if(unit === 'Mi'){
+    return parseFloat(string) * Math.pow(10, 6);
+  } else if (unit === 'Gi'){
+    return parseFloat(string) * Math.pow(10, 9);
+  } else
+    return parseFloat(string);
+}
+
+export function convertCPU(string) {
+  let unit = string.slice(-1);
+  if(unit === 'k'){
+    return parseFloat(string) * Math.pow(10, 3);
+  } else if(unit === 'm'){
+    return parseFloat(string) * Math.pow(10, 6);
+  } else if (unit === 'g'){
+    return parseFloat(string) * Math.pow(10, 9);
+  } else if (unit === 'n'){
+    return parseFloat(string);
+  } else
+    return parseFloat(string) * Math.pow(10, 9);
+}

--- a/src/services/ApiManager.js
+++ b/src/services/ApiManager.js
@@ -586,10 +586,7 @@ export default class ApiManager {
     return this.apiCore.listNode();
   }
 
-  /** gets the metrics of pods for a specific namespace */
-  getMetricsPOD(namespace, name){
-    let url = window.APISERVER_URL + '/apis/metrics.k8s.io/v1beta1/namespaces/' + namespace + '/pods/' + name;
-
+  fetchMetrics(url){
     let headers = new Headers();
     headers.append("Authorization", "Bearer " + this.user.id_token);
 
@@ -599,23 +596,27 @@ export default class ApiManager {
       redirect: 'follow'
     };
 
-    return fetch(url, requestOptions).then(res => res.json());
+    return fetch(url, requestOptions).then(res => {
+      if (res.ok) {
+        return res.json();
+      } else {
+        return Promise.reject(res.status);
+      }
+    });
+  }
+
+  /** gets the metrics of pods for a specific namespace */
+  getMetricsPOD(namespace, name){
+    let url = window.APISERVER_URL + '/apis/metrics.k8s.io/v1beta1/namespaces/' + namespace + '/pods/' + name;
+
+    return this.fetchMetrics(url);
   }
 
   /** gets the metrics of all the nodes on the cluster */
   getMetricsNodes(){
     let url = window.APISERVER_URL + '/apis/metrics.k8s.io/v1beta1/nodes'
 
-    let headers = new Headers();
-    headers.append("Authorization", "Bearer " + this.user.id_token);
-
-    let requestOptions = {
-      method: 'GET',
-      headers: headers,
-      redirect: 'follow'
-    };
-
-    return fetch(url, requestOptions).then(res => res.json());
+    return this.fetchMetrics(url);
   }
 
 }

--- a/src/services/__mocks__/ApiManager.js
+++ b/src/services/__mocks__/ApiManager.js
@@ -215,7 +215,6 @@ export default class ApiManager {
             this.CVsNotifyEvent('MODIFIED', itemDC);
             return Promise.resolve(new Response(JSON.stringify(item)))
           }
-          //console.log(res)
           this.watchers.forEach(w => {
             if (w.plural === plural)
               w.callback('MODIFIED', res.body);

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -68,7 +68,10 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorMetric
     }  else if (req.url === 'http://localhost:3001/nodes') {
       return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
     } else if (req.url === 'http://localhost:3001/metrics/nodes') {
-      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+      if(errorMetrics)
+        return Promise.resolve(new Response(JSON.stringify({ items: [] })));
+      else
+        return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
     } else {
       return metricsPODs(req, errorMetrics);
     }
@@ -132,11 +135,15 @@ describe('ConnectedPeer', () => {
     await OKCheck();
   })
 
-  test('Error on pod metrics', async () => {
+  test('Error on pod metrics (404)', async () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse, false, true);
 
     await OKCheck();
-  })
+
+    await new Promise((r) => setTimeout(r, 31000));
+
+    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  }, 35000)
 
   test('Advertisement status is not accepted', async () => {
     mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);

--- a/test/RTLUtils.js
+++ b/test/RTLUtils.js
@@ -35,7 +35,7 @@ export function setup_login() {
 
 export function metricsPODs(req, error){
   if(error){
-    return Promise.reject(Error409.body);
+    return Promise.reject(404);
   } else if (req.url === 'http://localhost:3001/metrics/pods/hello-world-deployment-6756549f5-x66v9') {
     return Promise.resolve(new Response(JSON.stringify(PodsMetricsMockResponse.podMetrics[0])));
   } else if (req.url === 'http://localhost:3001/metrics/pods/hello-world-deployment-6756549f5-c7qzv') {

--- a/test/Status.test.js
+++ b/test/Status.test.js
@@ -57,7 +57,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorMetric
       if(!errorMetrics)
         return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
       else
-        return Promise.reject({ body: Error409 });
+        return Promise.reject(409);
     } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     } else {
@@ -85,13 +85,7 @@ describe('Status', () => {
     await OKCheck();
 
     await new Promise((r) => setTimeout(r, 31000));
-  }, 35000)
-
-  test('Error on metrics', async () => {
-    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, false, true);
-
-    await OKCheck();
-  })
+  }, 40000)
 
   test('Line chart NaN data', async () => {
     render(


### PR DESCRIPTION
## Description

With this PR when fetching the metrics server returns a 404 (or when the nodes metrics return an empty list for the physical and/or virtual nodes), the worst case scenario metrics are used. That means that the consumption of a single pod will be the requested resources of that pod, and the total consumed % of RAM/CPU is the sum of the pods' requested resources.

**Note that assuming the worst case scenario implies that the total consumed resources could be more than 100%, even though the actual total consumed resources is lower.**