### PR TITLE
Added nginx proxy

### DIFF
--- a/generate_config_js.sh
+++ b/generate_config_js.sh
@@ -11,10 +11,6 @@ if [ -z "${OIDC_CLIENT_SECRET:-}" ]; then
     OIDC_CLIENT_SECRET=undefined
 fi
 
-if [ -z "${APISERVER_URL:-}" ]; then
-    APISERVER_URL=undefined
-fi
-
 if [ -z "${OIDC_REDIRECT_URI:-}" ]; then
     OIDC_REDIRECT_URI=undefined
 fi
@@ -22,7 +18,6 @@ fi
 cat << EOF
 window.OIDC_PROVIDER_URL="$OIDC_PROVIDER_URL";
 window.OIDC_CLIENT_ID="$OIDC_CLIENT_ID";
-window.APISERVER_URL="$APISERVER_URL";
 window.OIDC_CLIENT_SECRET="$OIDC_CLIENT_SECRET";
 window.OIDC_REDIRECT_URI="$OIDC_REDIRECT_URI";
 EOF

--- a/kubernetes/config/dashboard-configmap.yaml
+++ b/kubernetes/config/dashboard-configmap.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: liqo-dashboard-env-vars
+  name: liqo-dashboard-configmap
   namespace: liqo
 data:
   oidc_client_id: "__OIDC_CLIENT_ID__"
   oidc_provider_url: "__OIDC_PROVIDER_URL__"
   oidc_client_secret: "__OIDC_CLIENT_SERVER__"
   oidc_redirect_uri: "__DASHBOARD__URL__"
-  apiserver_url: "__APISERVER_URL__"

--- a/kubernetes/config/dashboard-deploy.yaml
+++ b/kubernetes/config/dashboard-deploy.yaml
@@ -15,8 +15,22 @@ spec:
       labels:
         app: liqo-dashboard
     spec:
+      volumes:
+        - name: shared-data
+          emptyDir: { }
+        initContainers:
+          - name: proxy-cert
+            image: nginx
+            volumeMounts:
+              - name: shared-data
+                mountPath: /etc/nginx/ssl/
+            command: [ "/bin/sh" ]
+            args: [ "-c", 'openssl req -x509 -subj "/C=IT/ST=Turin/O=Liqo" -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.cert' ]
       containers:
         - image: liqo/dashboard:latest
+          volumeMounts:
+            - name: shared-data
+              mountPath: /etc/nginx/ssl/
           imagePullPolicy: Always
           name: liqo-dashboard
           ports:
@@ -27,25 +41,20 @@ spec:
             - name: OIDC_PROVIDER_URL
               valueFrom:
                 configMapKeyRef:
-                  name: liqo-dashboard-env-vars
+                  name: liqo-dashboard-configmap
                   key: oidc_provider_url
             - name: OIDC_CLIENT_ID
               valueFrom:
                 configMapKeyRef:
-                  name: liqo-dashboard-env-vars
+                  name: liqo-dashboard-configmap
                   key: oidc_client_id
             - name: OIDC_CLIENT_SECRET
               valueFrom:
                 configMapKeyRef:
-                  name: liqo-dashboard-env-vars
+                  name: liqo-dashboard-configmap
                   key: oidc_client_secret
             - name: OIDC_REDIRECT_URI
               valueFrom:
                 configMapKeyRef:
-                  name: liqo-dashboard-env-vars
+                  name: liqo-dashboard-configmap
                   key: oidc_redirect_uri
-            - name: APISERVER_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: liqo-dashboard-env-vars
-                  key: apiserver_url  

--- a/kubernetes/config/dashboard-svc.yaml
+++ b/kubernetes/config/dashboard-svc.yaml
@@ -10,7 +10,7 @@ spec:
   selector:
     app: liqo-dashboard
   ports:
-    - name: http
+    - name: https
       protocol: TCP
-      port: 80
-      targetPort: 80
+      port: 443
+      targetPort: 443

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,12 @@
 server {
-    listen       80;
-    server_name  localhost;
+    listen              443 ssl http2;
+    server_name         localhost;
+    http2_recv_timeout  3600s;
+    proxy_buffering     off;
+    ssl_certificate     /etc/nginx/ssl/nginx.cert;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;
 
@@ -8,6 +14,44 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri /index.html;
+    }
+
+    location /apiserver {
+    	proxy_set_header Authorization $http_authorization;
+    	proxy_read_timeout  3600s;
+
+    	if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        #
+        # Custom headers and headers various browsers *should* be OK with but aren't
+        #
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        #
+        # Tell client that this pre-flight info is valid for 20 days
+        #
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
+     }
+     if ($request_method = 'POST') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+     }
+     if ($request_method = 'GET') {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
+        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range';
+     }
+
+    	rewrite /apiserver/(.*) /$1  break;
+  	proxy_pass         https://kubernetes.default.svc.cluster.local;
+  	proxy_redirect     off;
+  	proxy_set_header   Host $host;
     }
 
     #error_page  404              /404.html;

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -35,6 +35,9 @@ class App extends Component {
       user: {}
     }
 
+    /** Set the URL to which we make the call to the proxy */
+    window.APISERVER_URL = window.location.protocol + '//' + window.location.hostname + ':' + window.location.port + '/apiserver';
+
     /** Manage the login via token */
     this.manageToken = this.manageToken.bind(this);
     /** Manage the logout via token */

--- a/src/services/ApiManager.js
+++ b/src/services/ApiManager.js
@@ -15,9 +15,6 @@ export default class ApiManager {
    *
    */
   constructor(user) {
-    if (window.APISERVER_URL === undefined) {
-      window.APISERVER_URL = APISERVER_URL;
-    }
     this.user = user;
     this.kcc = new Config(window.APISERVER_URL, user.id_token, user.token_type);
     this.apiExt = this.kcc.makeApiClient(ApiextensionsV1beta1Api);

--- a/src/services/__mocks__/Authenticator.js
+++ b/src/services/__mocks__/Authenticator.js
@@ -41,7 +41,7 @@ export default class Authenticator {
     this.OIDC = false;
     this.token = '';
 
-    if (window.APISERVER_URL) {
+    if (window.OIDC_PROVIDER_URL) {
       this.OIDC = true;
       this.manager = getManager();
     }

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -19,7 +19,6 @@ fetchMock.enableMocks();
 let api;
 
 async function setup() {
-  window.APISERVER_URL = true;
   window.OIDC_PROVIDER_URL = 'test-url';
   window.OIDC_CLIENT_ID = 'test-id';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,7 +80,6 @@ module.exports = {
     new webpack.DefinePlugin({
       OIDC_PROVIDER_URL: JSON.stringify(process.env.OIDC_PROVIDER_URL),
       OIDC_CLIENT_ID: JSON.stringify(process.env.OIDC_CLIENT_ID),
-      APISERVER_URL: JSON.stringify(process.env.APISERVER_URL),
       OIDC_REDIRECT_URI: JSON.stringify(process.env.OIDC_REDIRECT_URI),
       OIDC_CLIENT_SECRET: JSON.stringify(process.env.OIDC_CLIENT_SECRET)
     })

--- a/webpack_docker.config.js
+++ b/webpack_docker.config.js
@@ -80,7 +80,6 @@ module.exports = {
     new webpack.DefinePlugin({
       OIDC_PROVIDER_URL: JSON.stringify(process.env.OIDC_PROVIDER_URL),
       OIDC_CLIENT_ID: JSON.stringify(process.env.OIDC_CLIENT_ID),
-      APISERVER_URL: JSON.stringify(process.env.APISERVER_URL),
       OIDC_REDIRECT_URI: JSON.stringify(process.env.OIDC_REDIRECT_URI),
       OIDC_CLIENT_SECRET: JSON.stringify(process.env.OIDC_CLIENT_SECRET)
     })


### PR DESCRIPTION
## Description

This PR adds a proxy in the nginx configuration. The connection with the proxy is over TLS (with the certificate and key created by a sidecar container) and using HTTP/2. 
Using a proxy to manage the call to the Kubernetes api server, there is no need to specify it in the dashboard, that will just call a path preceded by _/apiserver_ and then the proxy will forward it to the actual Kubernetes api server.