### PR TITLE
Home view shows when there is no metrics server

### DIFF
--- a/src/home/ConnectedPeer.js
+++ b/src/home/ConnectedPeer.js
@@ -458,6 +458,8 @@ class ConnectedPeer extends Component {
 
         { /** This modal shows the detail of the connection */ }
         <ConnectionDetails {...this.props} _this={this}
+                           metricsNotAvailableIncoming={this.metricsNotAvailableIncoming}
+                           metricsNotAvailableOutgoing={this.metricsNotAvailableOutgoing}
                            outgoingPodsPercentage={this.state.outgoingPodsPercentage}
                            incomingPodsPercentage={this.state.incomingPodsPercentage}
                            outgoingTotalPercentage={this.state.outgoingTotalPercentage}

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -8,6 +8,7 @@ import HomeOutlined from '@ant-design/icons/lib/icons/HomeOutlined';
 import GlobalOutlined from '@ant-design/icons/lib/icons/GlobalOutlined';
 import { getColor } from './HomeUtils';
 import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
+import ExclamationCircleTwoTone from '@ant-design/icons/lib/icons/ExclamationCircleTwoTone';
 
 const n = Math.pow(10, 6);
 
@@ -130,8 +131,10 @@ class ConnectionDetails extends Component {
         dataIndex: 'RAM',
         key: 'RAM',
         render: (text, record) => {
-          let podRAMmb = (role && this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name})) ?
-            this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name}).RAMmi / n : 0;
+          let podRAMmb = role ? (this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name}) ?
+            this.props.incomingPodsPercentage.find(pod => {return record.key === pod.name}).RAMmi / n : 0) :
+            (this.props.outgoingPodsPercentage.find(pod => {return record.key === pod.name}) ?
+            this.props.outgoingPodsPercentage.find(pod => {return record.key === pod.name}).RAMmi / n : 0)
 
           return(
             <Tooltip title={podRAMmb + 'Mi'}>
@@ -193,7 +196,17 @@ class ConnectionDetails extends Component {
         <div style={{marginTop: 10}}>
           <Row>
             <Col flex={1}>
-              <Card title={'Resources Used'} style={{marginRight: 20}}>
+              <Card title={'Resources Used'} style={{marginRight: 20}}
+                    extra={role ? (this.props.metricsNotAvailableIncoming ? (
+                      <Tooltip title={'Precise metrics not available in your cluster'}>
+                        <ExclamationCircleTwoTone twoToneColor="#f5222d" />
+                      </Tooltip>
+                    ) : null) : (this.props.metricsNotAvailableOutgoing ? (
+                      <Tooltip title={'Precise metrics not available in this cluster'}>
+                        <ExclamationCircleTwoTone twoToneColor="#f5222d" />
+                      </Tooltip>
+                    ) : null)}
+              >
                 <Row gutter={[20, 20]} align={'center'} justify={'center'}>
                   <Col>
                     <Row justify={'center'}>


### PR DESCRIPTION
## Description

This PR adds a little "!" when there is no metrics server available to retrieve the actual status of the clusters, notifying the user that there is no metrics server available (either for the home cluster, or the foreign ones).
The icon will show up in the details of the connection and in the status view.
![image](https://user-images.githubusercontent.com/38859529/91875692-24757a00-ec7c-11ea-9094-c444af5265ab.png)
![image](https://user-images.githubusercontent.com/38859529/91875785-41aa4880-ec7c-11ea-9c14-49f8c6ac9fe4.png)
