### PR TITLE
Nodes metrics when metrics server respond with 404

### DIFF
--- a/src/home/ConnectedPeer.js
+++ b/src/home/ConnectedPeer.js
@@ -303,7 +303,10 @@ class ConnectedPeer extends Component {
           if(res.items.filter(no => { return no.metadata.name.slice(0, 5) === 'liqo-' }).length !== 0)
             this.metricsNotAvailableOutgoing = true;
         }
-      })
+      }).catch(() => {
+        this.metricsNotAvailableIncoming = true;
+        this.metricsNotAvailableOutgoing = true;
+    })
   }
 
   componentWillUnmount() {

--- a/test/Status.test.js
+++ b/test/Status.test.js
@@ -57,7 +57,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorMetric
       if(!errorMetrics)
         return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
       else
-        return Promise.reject(409);
+        return Promise.reject(404);
     } else if (req.url === 'http://localhost:3001/pod') {
       return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
     } else {
@@ -86,6 +86,14 @@ describe('Status', () => {
 
     await new Promise((r) => setTimeout(r, 31000));
   }, 40000)
+
+  test('404 on node metrics', async () => {
+    mocks(AdvMockResponse, FCMockResponse, PRMockResponse, false, true);
+
+    await OKCheck();
+
+    expect(await screen.findAllByLabelText('exclamation-circle')).toHaveLength(2);
+  })
 
   test('Line chart NaN data', async () => {
     render(


### PR DESCRIPTION
## Description
This PR handles situations where the api server responds with a 404 when asked for nodes metrics. The way it handles it is the same as when the response is an empty list, that is considering every pod in the cluster (not the ones offloaded to other foreign clusters) consuming so much cpu and memory as specified in the request parameter of that pod.