### PR TITLE
Fix metrics showing NaN on connected peer

### DIFF
--- a/__mocks__/configs.json
+++ b/__mocks__/configs.json
@@ -13,7 +13,9 @@
         "advertisementConfig": {
           "autoAccept": true,
           "maxAcceptableAdvertisement": 10,
-          "resourceSharingPercentage": 63
+          "outgoingConfig": {
+            "resourceSharingPercentage": 63
+          }
         },
         "discoveryConfig": {
           "autojoin": true,

--- a/__mocks__/configs_updated.json
+++ b/__mocks__/configs_updated.json
@@ -10,7 +10,9 @@
     "advertisementConfig": {
       "autoAccept": true,
       "maxAcceptableAdvertisement": 10,
-      "resourceSharingPercentage": 63
+      "outgoingConfig": {
+        "resourceSharingPercentage": 63
+      }
     },
     "discoveryConfig": {
       "autojoin": false,

--- a/src/home/ConnectedPeer.js
+++ b/src/home/ConnectedPeer.js
@@ -95,8 +95,8 @@ class ConnectedPeer extends Component {
     home_totalPodsRAM += podPercentage.RAMmi;
     home_totalPodsCPU += podPercentage.CPUmi;
 
-    let totalRAMPercentage = home_totalPodsRAM / (home_totalMemory * this.props.config.spec.advertisementConfig.resourceSharingPercentage / 100) * 100;
-    let totalCPUPercentage = home_totalPodsCPU / (home_totalCPU * this.props.config.spec.advertisementConfig.resourceSharingPercentage / 100) * 100;
+    let totalRAMPercentage = home_totalPodsRAM / (home_totalMemory * this.props.config.spec.advertisementConfig.outgoingConfig.resourceSharingPercentage / 100) * 100;
+    let totalCPUPercentage = home_totalPodsCPU / (home_totalCPU * this.props.config.spec.advertisementConfig.outgoingConfig.resourceSharingPercentage / 100) * 100;
 
     if(home_counter === this.state.incomingPods.length){
       this.setState({


### PR DESCRIPTION
## Description
This little PR fixes a bug where the home view would show a NaN or 0% of resources consumed for the connected peers (only for the incoming pods). That was because of a wrong call to a clusterConfig's parameter.