### PR TITLE
Metrics when a pod has no requested resources

### DIFF
--- a/__mocks__/pods.json
+++ b/__mocks__/pods.json
@@ -47,16 +47,7 @@
                 "protocol": "TCP"
               }
             ],
-            "resources": {
-              "limits": {
-                "cpu": "250m",
-                "memory": "256Mi"
-              },
-              "requests": {
-                "cpu": "80m",
-                "memory": "128Mi"
-              }
-            },
+            "resources": {},
             "volumeMounts": [
               {
                 "name": "default-token-mbjjj",

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -81,16 +81,40 @@ class ConnectionDetails extends Component {
           setTimeout(() => searchText.select());
         }
       },
-      render: text =>
-        dataIndex === 'Status' ? (
-          text === 'Running' ? <Tag color={'blue'}>{text}</Tag> : <Tag color={'red'}>{text}</Tag>
-        ) : (
-          dataIndex === 'Namespace' ? (
-            <Tooltip title={text}>
-              <Tag style={{ maxWidth: '5vw', overflow: 'hidden', textOverflow: 'ellipsis'}}>{text}</Tag>
-            </Tooltip>
-          ) : text
-        ),
+      render: text => {
+
+        let podNoRes = role ? this.props.incomingPodsPercentage.find(pod => {return text === pod.name}) :
+          this.props.outgoingPodsPercentage.find(pod => {return text === pod.name})
+
+        return (
+          dataIndex === 'Status' ? (
+            text === 'Running' ? <Tag color={'blue'}>{text}</Tag> : <Tag color={'red'}>{text}</Tag>
+          ) : (
+            dataIndex === 'Namespace' ? (
+              <Tooltip title={text}>
+                <Tag style={{ maxWidth: '5vw', overflow: 'hidden', textOverflow: 'ellipsis'}}>{text}</Tag>
+              </Tooltip>
+            ) : (
+              <Row>
+                <Col>
+                  <Tooltip title={text}>
+                    <div style={{ maxWidth: '10vw', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>
+                      {text}
+                    </div>
+                  </Tooltip>
+                </Col>
+                { podNoRes && !podNoRes.resourcesRequestsPresent ? (
+                  <Col>
+                    <Tooltip title={'POD doesn\'t have a resource limit'}>
+                      <ExclamationCircleTwoTone style={{marginLeft: 4}} twoToneColor="#f5222d" />
+                    </Tooltip>
+                  </Col>
+                ) : null }
+              </Row>
+            )
+          )
+        )
+      }
     });
 
     const column = [
@@ -182,7 +206,7 @@ class ConnectionDetails extends Component {
 
     return(
       <Table size={'small'} columns={column} dataSource={data}
-             pagination={{ size: 'small', position: ['bottomCenter'], pageSize: 14 }} />
+             pagination={{ size: 'small', position: ['bottomCenter'], pageSize: 13 }} />
     )
   }
 

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -152,7 +152,7 @@ describe('ConnectedPeer', () => {
     await OKCheck();
   }, testTimeout)
 
-  test('Advertisement status is not accepted', async () => {
+  test('Advertisement has no status', async () => {
     mocks(AdvMockResponseNoStatus, FCMockResponse, PRMockResponse);
 
     await OKCheck();


### PR DESCRIPTION
## Description

This PR handles the situations where a pod (or one of its containers) has no requested resources specified. That means that even when there is a metrics server that can tell how many resources that pod is consuming, there is no way to transform that number in percentage (because there are no upper limits). So, while always showing how much resources a pod is **consuming**, the **reserved** will be 0. Also, to notify the user that a pod has no requested resources specified, a little "!" is placed next to the pod's name, and hovering with the mouse over it will let the user know what's the problem.

![no-requested-res](https://user-images.githubusercontent.com/38859529/92398884-a1479e80-f129-11ea-9303-6d04584622dc.png)
