### PR TITLE
Dashboard wait for OIDC login to complete before showing views

### DIFF
--- a/src/services/Authenticator.js
+++ b/src/services/Authenticator.js
@@ -1,5 +1,6 @@
 import { UserManager } from 'oidc-client';
 import React from 'react';
+import Cookies from 'js-cookie';
 
 /**
  * Api class to manage authN
@@ -63,7 +64,7 @@ export default class Authenticator {
     if(this.OIDC) {
       return this.manager.signinRedirect().catch(error => {
         console.log('login', error);
-        this.logout();
+        this.logout().catch(error => console.log(error));
       });
     }
   }
@@ -76,7 +77,7 @@ export default class Authenticator {
     if(this.OIDC){
       return this.manager.signinRedirectCallback().catch(error => {
         console.log('completeLogin', error);
-        this.logout();
+        this.logout().catch(error => console.log(error));
       });
     }
   }
@@ -86,10 +87,9 @@ export default class Authenticator {
    * @return {Promise<void>}
    */
   logout() {
-    if(this.OIDC)
+    if(this.OIDC){
+      Cookies.remove('token');
       return this.manager.signoutRedirect();
-    else{
-
     }
   }
 }

--- a/src/templates/donut/Donut.js
+++ b/src/templates/donut/Donut.js
@@ -22,7 +22,8 @@ class Donut extends Component {
     }
 
     data.forEach(d => {
-      if(isNaN(d.value)) d.value = 0;
+      if(!isFinite(d.value))
+        d.value = 0;
       empty.value -= d.value;
     })
 

--- a/src/templates/line/LineChart.js
+++ b/src/templates/line/LineChart.js
@@ -10,9 +10,8 @@ class LineChart extends Component {
   render(){
     let data = [];
     this.props.data.forEach(res => {
-      if(isNaN(res.value)){
+      if(!isFinite(res.value))
         res.value = 0;
-      }
       data.push(res);
     })
 

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
-import { loginTest, mockCRDAndViewsExtended } from './RTLUtils';
+import { loginTest, metricsPODs, mockCRDAndViewsExtended } from './RTLUtils';
 import { render, screen } from '@testing-library/react';
 import ApiManager from '../src/services/__mocks__/ApiManager';
 import { MemoryRouter } from 'react-router-dom';
@@ -14,6 +14,9 @@ import Error404 from '../__mocks__/404.json';
 import App from '../src/app/App';
 import ViewMockResponse from '../__mocks__/views.json';
 import { testTimeout } from '../src/constants';
+import PodsMockResponse from '../__mocks__/pods.json';
+import NodesMockResponse from '../__mocks__/nodes.json';
+import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
 
 fetchMock.enableMocks();
 
@@ -47,6 +50,14 @@ function mocks(){
       return Promise.reject(Error404.body);
     } else if (url === 'http://localhost:3001/clustercustomobject/views') {
       return Promise.resolve(new Response(JSON.stringify({ body: ViewMockResponse })))
+    } else if (url === 'http://localhost:3001/pod') {
+      return Promise.resolve(new Response(JSON.stringify({body: PodsMockResponse})));
+    } else if (url === 'http://localhost:3001/nodes') {
+      return Promise.resolve(new Response(JSON.stringify({body: NodesMockResponse})));
+    } else if (url === 'http://localhost:3001/metrics/nodes') {
+      return Promise.resolve(new Response(JSON.stringify(NodesMetricsMockResponse)));
+    } else {
+      return metricsPODs({url : url});
     }
   })
 }

--- a/test/Login.test.js
+++ b/test/Login.test.js
@@ -1,10 +1,8 @@
 import { screen } from '@testing-library/react'
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import userEvent from '@testing-library/user-event';
 import fetchMock from 'jest-fetch-mock';
-import ErrorMockResponse from '../__mocks__/401.json';
-import { loginTest, mockCRDAndViewsExtended, setup_login } from './RTLUtils';
+import { loginTest, mockCRDAndViewsExtended } from './RTLUtils';
 import { testTimeout } from '../src/constants';
 
 fetchMock.enableMocks();
@@ -17,26 +15,5 @@ describe('Login', () => {
 
     /** Assert that a success notification has spawned */
     expect(await screen.findByText(/successfully/i)).toBeInTheDocument();
-  }, testTimeout)
-
-  test('Login works when the token is invalid', async  () => {
-    fetch.mockImplementation((url) => {
-      if (url === 'http://localhost:3001/customresourcedefinition') {
-        return Promise.reject(new Response(JSON.stringify(ErrorMockResponse)))
-      }
-    })
-
-    setup_login();
-
-    /** Input mock password */
-    const tokenInput = screen.getByLabelText('lab');
-    userEvent.type(tokenInput, 'password');
-
-    /** Click on login button */
-    const submitButton = screen.getByRole('button');
-    userEvent.click(submitButton);
-
-    /** Assert that the token has been rejected */
-    expect(await screen.findByText(/valid/i)).toBeInTheDocument();
   }, testTimeout)
 })


### PR DESCRIPTION
## Description
With this PR, the dashboard waits for the OIDC login to complete before showing any view. That prevents some discrepancy in the CRDs fetched and the data visualization in the home view.

Other minor features:
- The token used for the authentication is now stored in a cookie even with the OIDC login (instead of the session storage).
- Managed situations where calculations of the percentages of the clusters return NaN or Infinity.
- Managed situations where the Liqo CRD are added after the Home View is displayed (so there is no need to refresh the page!).