### PR TITLE
Easy custom view creator

### DIFF
--- a/__mocks__/views_another.json
+++ b/__mocks__/views_another.json
@@ -1,0 +1,28 @@
+{
+  "apiVersion": "test/v1",
+  "items": [
+    {
+      "apiVersion": "test/v1",
+      "kind": "View",
+      "metadata": {
+        "name": "test-custom-view",
+        "resourceVersion": "000000",
+        "selfLink": "/apis/test/v1/namespaces/default/views/awesome-view"
+      },
+      "spec": {
+        "viewName": "Test Custom View",
+        "crds": [
+          {
+            "crdName": "advertisements.protocol.liqo.io"
+          }
+        ]
+      }
+    }
+  ],
+  "kind": "ViewList",
+  "metadata": {
+    "continue": "",
+    "resourceVersion": "0000000"
+  }
+}
+

--- a/src/CRD/CRD.js
+++ b/src/CRD/CRD.js
@@ -21,6 +21,7 @@ import LayoutOutlined from '@ant-design/icons/lib/icons/LayoutOutlined';
 import { Menu } from 'antd';
 import NewCR from '../editors/NewCR';
 import DesignEditorCRD from '../editors/DesignEditorCRD';
+import AddCustomView from '../views/AddCustomView';
 
 class CRD extends Component {
   constructor(props) {
@@ -294,6 +295,9 @@ class CRD extends Component {
     const menu = (
       <Menu>
         {items}
+        <Menu.Item key="addCV" >
+          <AddCustomView api={this.props.api} selected={this.state.CRD.metadata.name} />
+        </Menu.Item>
       </Menu>
     );
 

--- a/src/common/SideBar.js
+++ b/src/common/SideBar.js
@@ -8,6 +8,7 @@ import SettingOutlined from '@ant-design/icons/lib/icons/SettingOutlined';
 import LayoutOutlined from '@ant-design/icons/lib/icons/LayoutOutlined';
 import StarOutlined from '@ant-design/icons/lib/icons/StarOutlined';
 import { APP_NAME } from '../constants';
+import AddCustomView from '../views/AddCustomView';
 
 const Sider = Layout.Sider;
 
@@ -125,7 +126,10 @@ class SideBar extends Component {
             </Menu.Item>
             <Menu.Divider/>
             {cv}
-            {cv.length ? <Menu.Divider/> : null}
+            <Menu.Item key="addCV" style={{ marginTop: 8}}>
+              <AddCustomView api={this.props.api} />
+            </Menu.Item>
+            <Menu.Divider/>
             <Menu.Item key="2" style={{ marginTop: 8}}>
               <Link to="/customresources">
                 <DesktopOutlined style={{ fontSize: '20px' }} />

--- a/src/services/__mocks__/ApiManager.js
+++ b/src/services/__mocks__/ApiManager.js
@@ -166,12 +166,13 @@ export default class ApiManager {
     return fetch('http://localhost:3001/clustercustomobject/' + plural, { method: 'POST', body: item})
       .then(res => res.json())
       .then((res) => {
-
+        if(plural === 'views'){
+          this.manageCallbackCVs(res.body.items);
+        }
         this.watchers.forEach(w => {
           if (w.plural === plural)
             w.callback('ADDED', res.body);
         })
-
       });
   }
 

--- a/src/services/stringUtils.js
+++ b/src/services/stringUtils.js
@@ -15,6 +15,13 @@ export function properCase(str) {
 }
 
 /**
+ * LOWERCASE and replace spaces with dashes
+ */
+export function dashLowercase(str) {
+  return lowerCase(str).replace(/\s+/g, '-');
+}
+
+/**
  * "Safer" String.toUpperCase()
  */
 export function upperCase(str) {

--- a/src/views/AddCustomView.js
+++ b/src/views/AddCustomView.js
@@ -1,0 +1,134 @@
+import { Alert, Modal, Select, Input, Typography, Row, Col, Badge, notification } from 'antd';
+import React, { useRef, useState } from 'react';
+import PlusSquareOutlined from '@ant-design/icons/lib/icons/PlusSquareOutlined';
+import PlusSquareTwoTone from '@ant-design/icons/lib/icons/PlusSquareTwoTone';
+import { dashLowercase } from '../services/stringUtils';
+import { APP_NAME } from '../constants';
+
+function AddCustomView(props){
+  const [showAddCV, setShowAddCV] = useState(false);
+  const [selectedCRDs, setSelectedCRDs] = useState(() => {
+    if(props.selected)
+      return [props.selected];
+    else return [];
+  });
+  const [noNameAlert, setNoNameAlert] = useState(false);
+  let viewName = useRef('');
+
+  let options = [];
+
+  props.api.CRDs.forEach(CRD => options.push(CRD.metadata.name));
+
+  const filteredOptions = options.filter(CRD => !selectedCRDs.includes(CRD));
+
+  const handleChange = items => {
+    setSelectedCRDs(items);
+  };
+
+  const handleSubmit = () => {
+    if(viewName.current === '')
+      setNoNameAlert(true);
+    else {
+      let namespace = 'default';
+      let CRD = props.api.getCRDfromKind('View');
+
+      let crds = [];
+      selectedCRDs.forEach(crd => {
+        crds.push({
+          crdName: crd
+        });
+      })
+
+      let item = {
+        apiVersion: CRD.spec.group + '/' + CRD.spec.version,
+        kind: CRD.spec.names.kind,
+        metadata: {
+          name: dashLowercase(viewName.current),
+          namespace: namespace
+        },
+        spec: {
+          crds: crds,
+          viewName: viewName.current
+        }
+      }
+
+      props.api.createCustomResource(
+        CRD.spec.group,
+        CRD.spec.version,
+        namespace,
+        CRD.spec.names.plural,
+        item
+      ).then(() => {
+        setShowAddCV(false);
+      }).catch(error => {
+        console.log(error);
+        notification.error({
+          message: APP_NAME,
+          description: 'Could not create custom view'
+        });
+      });
+    }
+  }
+
+  return(
+    <div>
+      <div onClick={() => setShowAddCV(true)}>
+        {props.selected ? (
+          <Row align={'middle'}>
+            <PlusSquareTwoTone style={{ fontSize: '20px', marginRight: '8px' }} />
+            <a>New Custom View</a>
+          </Row>
+        ) : (
+          <div>
+            <PlusSquareOutlined style={{ fontSize: '20px' }} />
+            <span>New Custom View</span>
+          </div>
+        )}
+      </div>
+      <Modal
+        destroyOnClose
+        title={'New Custom View'}
+        visible={showAddCV}
+        onOk={handleSubmit}
+        onCancel={() => setShowAddCV(false)}
+      >
+        { noNameAlert ? (
+          <Alert message="Please choose a name for your custom view" type="error" showIcon style={{marginBottom: 16}} />
+        ) : null }
+        <Row align={'middle'} gutter={[16, 16]}>
+          <Col span={6}>
+            <Badge text={<Typography.Text strong>View Name</Typography.Text>} status={'processing'} />
+          </Col>
+          <Col span={18}>
+            <Input placeholder={'Insert name'} role={'input'}
+                   onChange={e => {viewName.current = e.target.value}}
+            />
+          </Col>
+        </Row>
+        <Row align={'middle'} gutter={[16, 16]}>
+          <Col span={6}>
+            <Badge text={<Typography.Text strong>CRDs</Typography.Text>} status={'processing'} />
+          </Col>
+          <Col span={18}>
+            <Select
+              aria-label={'select'}
+              mode={'multiple'}
+              placeholder={'Select CRDs'}
+              value={selectedCRDs}
+              style={{ width: '100%' }}
+              onChange={handleChange}
+            >
+              {filteredOptions.map(CRD => (
+                <Select.Option key={CRD} value={CRD}>
+                  {CRD}
+                </Select.Option>
+              ))}
+            </Select>
+          </Col>
+        </Row>
+      </Modal>
+    </div>
+  )
+}
+
+export default AddCustomView;

--- a/test/CRD.test.js
+++ b/test/CRD.test.js
@@ -432,4 +432,33 @@ describe('CRD', () => {
 
     api = null;
   }, testTimeout)
+
+  test('CRD dropdown custom view new custom view', async () => {
+    await setup_only_CRD(true);
+
+    expect(await screen.findByText('LiqoDashTest')).toBeInTheDocument();
+
+    let layout = await screen.findByLabelText('layout');
+
+    userEvent.click(layout);
+
+    userEvent.click(await screen.findByText('New Custom View'));
+
+    expect(await screen.findAllByText('New Custom View')).toHaveLength(2);
+
+    const name = await screen.findByRole('input');
+    await userEvent.type(name, 'Test Custom View');
+    const crds = await screen.findAllByLabelText('select');
+    userEvent.click(crds[0]);
+    userEvent.click(crds[1]);
+    const adv = await screen.findAllByText('advertisements.protocol.liqo.io');
+
+    fireEvent.mouseOver(adv[0]);
+    fireEvent.click(adv[0]);
+
+    userEvent.click(await screen.findByText('OK'));
+
+    expect(await screen.findByText('Could not create custom view'));
+    api = null;
+  }, testTimeout)
 })

--- a/test/CRDList.test.js
+++ b/test/CRDList.test.js
@@ -50,7 +50,7 @@ describe('CRD List', () => {
 
     expect(await screen.findAllByRole('row')).toHaveLength(3);
 
-  })
+  }, testTimeout)
 
   test('CRD list cards show all the data and the right description', async () => {
     await setup();

--- a/test/RTLUtils.js
+++ b/test/RTLUtils.js
@@ -4,6 +4,7 @@ import App from '../src/app/App';
 import CRDmockResponse from '../__mocks__/crd_fetch.json';
 import ViewMockResponseLayout from '../__mocks__/views_withLayout.json';
 import ViewMockResponse from '../__mocks__/views.json';
+import NewViewMockResponse from '../__mocks__/views_another.json';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import AdvMockResponse from '../__mocks__/advertisement.json';
@@ -107,6 +108,8 @@ export function mockCRDAndViewsExtended(error, method, crd, view) {
         }
       } else if (req.method === 'PUT'){
         return Promise.resolve(new Response(JSON.stringify({body: ViewMockResponse})));
+      } else if (req.method === 'POST'){
+        return Promise.resolve(new Response(JSON.stringify({body: NewViewMockResponse})));
       }
     }  else if (req.url === 'http://localhost:3001/clustercustomobject/liqodashtests') {
       return responseManager(req, error, method, crd, 'liqodashtests',

--- a/test/SideBar.test.js
+++ b/test/SideBar.test.js
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
@@ -16,7 +16,7 @@ describe('Sidebar', () => {
 
     expect(await screen.findAllByText(/Home/i)).toHaveLength(2);
 
-    expect(await screen.findByText(/custom/i)).toBeInTheDocument();
+    expect(await screen.findByText(/custom resources/i)).toBeInTheDocument();
 
     expect(await screen.findByText(/favourites/i)).toBeInTheDocument();
 
@@ -61,6 +61,55 @@ describe('Sidebar', () => {
     userEvent.click(await screen.findByLabelText('left'));
 
     expect(await screen.queryByLabelText('left')).not.toBeInTheDocument();
+  }, testTimeout)
+
+  test('New Custom View works', async () => {
+    mockCRDAndViewsExtended();
+    await loginTest();
+
+    userEvent.click(await screen.findByText('New Custom View'));
+
+    expect(await screen.findAllByText('New Custom View')).toHaveLength(2);
+
+    const name = await screen.findByRole('input');
+    await userEvent.type(name, 'Test Custom View');
+    let crds = await screen.findAllByLabelText('select');
+    userEvent.click(crds[0]);
+    userEvent.click(crds[1]);
+    const adv = await screen.findAllByText('advertisements.protocol.liqo.io');
+
+    fireEvent.mouseOver(adv[1]);
+    fireEvent.click(adv[1]);
+
+    userEvent.click(await screen.findByText('OK'));
+
+    expect(await screen.findByText('Test Custom View')).toBeInTheDocument();
+  }, testTimeout)
+
+  test('New Custom View with no name throws error', async () => {
+    mockCRDAndViewsExtended();
+    await loginTest();
+
+    userEvent.click(await screen.findByText('New Custom View'));
+
+    expect(await screen.findAllByText('New Custom View')).toHaveLength(2);
+
+    userEvent.click(await screen.findByText('OK'));
+
+    expect(await screen.findByText(/Please/i)).toBeInTheDocument();
+  }, testTimeout)
+
+  test('New Custom View cancel', async () => {
+    mockCRDAndViewsExtended();
+    await loginTest();
+
+    userEvent.click(await screen.findByText('New Custom View'));
+
+    expect(await screen.findAllByText('New Custom View')).toHaveLength(2);
+
+    userEvent.click(await screen.findByText('Cancel'));
+
+    expect(await screen.queryByText('Test Custom View')).not.toBeInTheDocument();
   }, testTimeout)
 })
 


### PR DESCRIPTION
## Description
This PR introduces two new and more direct (and easy) way to create a custom view:
- From the sidebar, clicking the 'New Custom View' menu item will open a modal where the name of the custom view can be choose and the CRDs to put in it (with an autocomplete function that let you choose from the CRD that are present in your cluster)
![image](https://user-images.githubusercontent.com/38859529/93310777-7e8e4780-f805-11ea-8fdd-ba89dc48bc86.png)
- From a CRD, clicking the 'New Custom View' menu item under the views dropdown menu. It will open a modal identical to the one described above, but with the CRD you are on already inserted.
![image](https://user-images.githubusercontent.com/38859529/93310865-99f95280-f805-11ea-9cfb-700879cf8a44.png)
**NOTE:** the views are created in the _default_ namespace
