### PR TITLE
Show name of foreign clusters instead of ID

### DIFF
--- a/__mocks__/configs.json
+++ b/__mocks__/configs.json
@@ -22,6 +22,7 @@
           "domain": "domain-test",
           "enableAdvertisement": true,
           "enableDiscovery": true,
+          "clusterName": "LIQO",
           "name": "name-test",
           "port": 12345,
           "service": "service-test",

--- a/__mocks__/configs_updated.json
+++ b/__mocks__/configs_updated.json
@@ -19,6 +19,7 @@
       "domain": "domain-test",
       "enableAdvertisement": true,
       "enableDiscovery": true,
+      "clusterName": "LIQO",
       "name": "name-test",
       "port": 12345,
       "service": "service-test",

--- a/__mocks__/crd_fetch.json
+++ b/__mocks__/crd_fetch.json
@@ -873,9 +873,19 @@
                     "description": "URL where to contact foreign API server",
                     "type": "string"
                   },
-                  "clusterID": {
-                    "description": "Foreign Cluster ID",
-                    "type": "string"
+                  "clusterIdentity": {
+                    "type": "object",
+                    "description": "Foreign Cluster Identity",
+                    "properties": {
+                      "clusterID": {
+                        "type": "string",
+                        "description": "Foreign Cluster ID, this is a unique identifier of that cluster"
+                      },
+                      "clusterName": {
+                        "type": "string",
+                        "description": "Foreign Cluster Name to be shown in GUIs"
+                      }
+                    }
                   },
                   "discoveryType": {
                     "type": "string",

--- a/__mocks__/foreigncluster.json
+++ b/__mocks__/foreigncluster.json
@@ -16,7 +16,10 @@
       "spec": {
         "allowUntrustedCA": true,
         "apiUrl": "https://1.1.1.1:1234",
-        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "clusterIdentity": {
+          "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "clusterName": "Cluster-Test"
+        },
         "discoveryType": "LAN",
         "join": true,
         "namespace": "liqo"

--- a/__mocks__/foreigncluster_new.json
+++ b/__mocks__/foreigncluster_new.json
@@ -13,7 +13,9 @@
   "spec": {
     "allowUntrustedCA": true,
     "apiUrl": "https://1.1.1.2:1234",
-    "clusterID": "9d73c01a-f23a-45dc-822b-7d3232683f53",
+    "clusterIdentity": {
+      "clusterID": "9d73c01a-f23a-45dc-822b-7d3232683f53"
+    },
     "discoveryType": "LAN",
     "join": true,
     "namespace": "liqo"

--- a/__mocks__/foreigncluster_noIncoming.json
+++ b/__mocks__/foreigncluster_noIncoming.json
@@ -16,7 +16,10 @@
       "spec": {
         "allowUntrustedCA": true,
         "apiUrl": "https://1.1.1.1:1234",
-        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "clusterIdentity": {
+          "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "clusterName": "Cluster-Test"
+        },
         "discoveryType": "LAN",
         "join": true,
         "namespace": "liqo"

--- a/__mocks__/foreigncluster_noJoin.json
+++ b/__mocks__/foreigncluster_noJoin.json
@@ -16,7 +16,10 @@
       "spec": {
         "allowUntrustedCA": true,
         "apiUrl": "https://1.1.1.1:1234",
-        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "clusterIdentity": {
+          "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "clusterName": "Cluster-Test"
+        },
         "discoveryType": "LAN",
         "join": false,
         "namespace": "liqo"

--- a/__mocks__/foreigncluster_noOutgoing.json
+++ b/__mocks__/foreigncluster_noOutgoing.json
@@ -16,7 +16,10 @@
       "spec": {
         "allowUntrustedCA": true,
         "apiUrl": "https://1.1.1.1:1234",
-        "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+        "clusterIdentity": {
+          "clusterID": "8d73c01a-f23a-45dc-822b-7d3232683f53",
+          "clusterName": "Cluster-Test"
+        },
         "discoveryType": "LAN",
         "join": true,
         "namespace": "liqo"

--- a/src/home/AvailablePeer.js
+++ b/src/home/AvailablePeer.js
@@ -19,6 +19,8 @@ import { getPeerProperties } from './PeerProperties';
 
 function AvailablePeer(props) {
 
+  const foreignClusterName = props.foreignCluster.spec.clusterIdentity.clusterName;
+  const foreignClusterID = props.foreignCluster.spec.clusterIdentity.clusterID;
   let lan = props.foreignCluster.spec.discoveryType === 'LAN';
   let [loading, setLoading] = useState(props.foreignCluster.spec.join);
   let [backgroundColor, setBackgroundColor] = useState('white');
@@ -140,9 +142,9 @@ function AvailablePeer(props) {
                   </Tooltip>
                 </Row>
               </div>
-              <Tooltip placement={'top'} title={props.foreignCluster.spec.clusterID}>
+              <Tooltip placement={'top'} title={foreignClusterID}>
                 <Tag color="blue" style={{ maxWidth: '13vw', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                  {props.foreignCluster.spec.clusterID}
+                  {foreignClusterName ? foreignClusterName : foreignClusterID}
                 </Tag>
               </Tooltip>
             </Space>

--- a/src/home/ConnectedPeer.js
+++ b/src/home/ConnectedPeer.js
@@ -20,6 +20,8 @@ function ConnectedPeer(props) {
    * @loading: if is connecting
    * @backgroundColor: if selected
    */
+  const foreignClusterName = props.foreignCluster.spec.clusterIdentity.clusterName;
+  const foreignClusterID = props.foreignCluster.spec.clusterIdentity.clusterID;
 
   const [loading, setLoading] = useState(false);
   const [backgroundColor, setBackgroundColor] = useState('white');
@@ -109,7 +111,7 @@ function ConnectedPeer(props) {
 
   useEffect(() => {
     props.updateFCMetrics(true, {
-      fc: props.foreignCluster.spec.clusterID,
+      fc: foreignClusterName ? foreignClusterName : foreignClusterID,
       RAM: incomingTotal.consumed.RAM,
       CPU: incomingTotal.consumed.CPU
     });
@@ -117,7 +119,7 @@ function ConnectedPeer(props) {
 
   useEffect(() => {
     props.updateFCMetrics(false, {
-      fc: props.foreignCluster.spec.clusterID,
+      fc: foreignClusterName ? foreignClusterName : foreignClusterID,
       RAM: outgoingTotal.consumed.RAM,
       CPU: outgoingTotal.consumed.CPU
     });
@@ -526,9 +528,9 @@ function ConnectedPeer(props) {
                   />
                 </Tooltip>
               </div>
-              <Tooltip placement={'top'} title={props.foreignCluster.spec.clusterID}>
+              <Tooltip placement={'top'} title={foreignClusterID}>
                 <Tag style={{ maxWidth: '10vw', overflow: 'hidden', textOverflow: 'ellipsis'}}
-                     color="blue">{props.foreignCluster.spec.clusterID}
+                     color="blue">{foreignClusterName ? foreignClusterName : foreignClusterID}
                 </Tag>
               </Tooltip>
             </Space>

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -13,7 +13,9 @@ import { getColumnSearchProps } from '../services/TableUtils';
 const n = Math.pow(10, 6);
 
 function ConnectionDetails(props) {
-  
+
+  const foreignClusterName = props.foreignCluster.spec.clusterIdentity.clusterName;
+  const foreignClusterID = props.foreignCluster.spec.clusterIdentity.clusterID;
   const [currentTab, setCurrentTab] = useState('1');
 
   const getUsedTotal = role => {
@@ -303,7 +305,7 @@ function ConnectionDetails(props) {
                     <>
                       Using
                       <> </>
-                      <Tag style={{marginRight: 3}}>{props.foreignCluster.spec.clusterID}</Tag>
+                      <Tag style={{marginRight: 3}}>{foreignClusterName ? foreignClusterName : foreignClusterID}</Tag>
                       's resources.
                     </>
                   }
@@ -315,7 +317,7 @@ function ConnectionDetails(props) {
                 { props.server ? (
                   <Badge text={
                     <>
-                      <Tag style={{marginRight: 3}}>{props.foreignCluster.spec.clusterID}</Tag>
+                      <Tag style={{marginRight: 3}}>{foreignClusterName ? foreignClusterName : foreignClusterID}</Tag>
                       <> </>
                       is using your resources.
                     </>

--- a/src/home/LiqoHeader.js
+++ b/src/home/LiqoHeader.js
@@ -37,7 +37,11 @@ function LiqoHeader(props) {
   return (
     <div className="home-header" style={{marginBottom: 16, height: '100%'}}>
       <PageHeader style={{paddingTop: '0.5em', paddingBottom: '0.5em'}}
-                  title={<Typography.Text strong style={{fontSize: '2em'}}>LIQO</Typography.Text>}
+                  title={
+                    <div>
+                      <Typography.Text strong style={{fontSize: '1.5em'}}>{props.config.spec.discoveryConfig.clusterName}</Typography.Text>
+                    </div>
+                  }
                   tags={
                     <Row align={'middle'}>
                       {running ? <Tag color="blue">Running</Tag> : <Tag color="red">Stopped</Tag>}
@@ -47,7 +51,6 @@ function LiqoHeader(props) {
                             <Typography.Text>Cluster ID:</Typography.Text>
                             <Typography.Paragraph style={{margin: 0}} copyable>{clusterID}</Typography.Paragraph>
                           </Space>
-
                         </Row>
                       </Tag>
                     </Row>

--- a/test/AvailableList.test.js
+++ b/test/AvailableList.test.js
@@ -84,7 +84,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
 }
 

--- a/test/AvailablePeer.test.js
+++ b/test/AvailablePeer.test.js
@@ -91,7 +91,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
 }
 
@@ -151,7 +151,7 @@ describe('AvailablePeer', () => {
     mocks(AdvMockResponse, FCMockResponseJoin, PRMockResponse);
     await setup();
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
     expect(await screen.findByText(/No peer available/i)).toBeInTheDocument();
 
     userEvent.click(await screen.findByText(/search/i));
@@ -161,7 +161,7 @@ describe('AvailablePeer', () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse);
     await OKCheck();
 
-    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+    userEvent.click(screen.getByText('Cluster-Test'));
 
     expect(await screen.findByText('Connect')).toBeInTheDocument();
 
@@ -198,7 +198,7 @@ describe('AvailablePeer', () => {
     mocks(AdvMockResponseNotAccepted, FCMockResponse, PRMockResponse);
     await OKCheck();
 
-    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+    userEvent.click(screen.getByText('Cluster-Test'));
 
     expect(await screen.findByText('Connect')).toBeInTheDocument();
 
@@ -233,7 +233,7 @@ describe('AvailablePeer', () => {
     mocks(AdvMockResponse, FCMockResponse, PRMockResponse, true);
     await OKCheck();
 
-    userEvent.click(screen.getAllByText('8d73c01a-f23a-45dc-822b-7d3232683f53')[0]);
+    userEvent.click(screen.getAllByText('Cluster-Test')[0]);
 
     expect(await screen.findByText('Connect')).toBeInTheDocument();
 
@@ -241,7 +241,7 @@ describe('AvailablePeer', () => {
 
     expect(await screen.findByText(/No peer connected/i)).toBeInTheDocument();
 
-    userEvent.click(screen.getAllByText('8d73c01a-f23a-45dc-822b-7d3232683f53')[0]);
+    userEvent.click(screen.getAllByText('Cluster-Test')[0]);
   }, testTimeout)
 
 })

--- a/test/ConnectedList.test.js
+++ b/test/ConnectedList.test.js
@@ -98,7 +98,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorPod, e
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
 }
 
@@ -147,7 +147,7 @@ describe('ConnectedList', () => {
       await new Promise((r) => setTimeout(r, 31000));
     })
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
 
     counter = 0;
   }, 60000)
@@ -167,6 +167,6 @@ describe('ConnectedList', () => {
     userEvent.click(disconnect[1]);
 
     expect(await screen.findByText(/Could not disconnect/i)).toBeInTheDocument();
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   }, testTimeout)
 })

--- a/test/ConnectedPeer.test.js
+++ b/test/ConnectedPeer.test.js
@@ -83,7 +83,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorMetric
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
 }
 
@@ -97,7 +97,7 @@ describe('ConnectedPeer', () => {
       await new Promise((r) => setTimeout(r, 31000));
     })
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   }, 60000)
 
   test('List of connected peers shows not incoming', async () => {
@@ -129,7 +129,7 @@ describe('ConnectedPeer', () => {
 
     await setup();
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
     expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
   }, testTimeout)
 
@@ -148,7 +148,7 @@ describe('ConnectedPeer', () => {
       await new Promise((r) => setTimeout(r, 31000));
     })
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   }, 60000)
 
   test('Advertisement status is not accepted', async () => {
@@ -187,7 +187,7 @@ describe('ConnectedPeer', () => {
     userEvent.click(disconnect);
 
     expect(await screen.findByText(/Could not disconnect/i)).toBeInTheDocument();
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
     expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
   }, testTimeout)
 
@@ -214,7 +214,7 @@ describe('ConnectedPeer', () => {
 
     expect(await screen.findByText(/Disconnected from/i)).toBeInTheDocument();
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
     expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
   }, testTimeout)
 })

--- a/test/ConnectionDetails.test.js
+++ b/test/ConnectionDetails.test.js
@@ -80,7 +80,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, podsError) 
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
 
   userEvent.click(screen.getByLabelText('ellipsis'));
@@ -119,7 +119,7 @@ describe('ConnectionDetails', () => {
 
     await setup();
 
-    expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+    expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
     expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
 
     userEvent.click(screen.getByLabelText('ellipsis'));

--- a/test/PeerProperties.test.js
+++ b/test/PeerProperties.test.js
@@ -86,14 +86,14 @@ function mocks(advertisement, foreignCluster, peeringRequest, error) {
 async function OKCheckAvailable() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer connected at the moment')).toBeInTheDocument();
 }
 
 async function OKCheckConnected() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
 }
 
@@ -103,7 +103,7 @@ describe('PeerProperties', () => {
 
     await OKCheckAvailable();
 
-    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+    userEvent.click(screen.getByText('Cluster-Test'));
     userEvent.click(await screen.findByText('Properties'));
 
     expect(await screen.findByText('Foreign Cluster')).toBeInTheDocument();
@@ -135,7 +135,7 @@ describe('PeerProperties', () => {
 
     expect(await screen.queryByText('Foreign Cluster')).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText('8d73c01a-f23a-45dc-822b-7d3232683f53'));
+    userEvent.click(screen.getByText('Cluster-Test'));
     userEvent.click(await screen.findByText('Properties'));
 
     expect(await screen.findByText('Foreign Cluster')).toBeInTheDocument();

--- a/test/Status.test.js
+++ b/test/Status.test.js
@@ -71,7 +71,7 @@ function mocks(advertisement, foreignCluster, peeringRequest, error, errorMetric
 async function OKCheck() {
   await setup();
 
-  expect(await screen.findByText('8d73c01a-f23a-45dc-822b-7d3232683f53')).toBeInTheDocument();
+  expect(await screen.findByText('Cluster-Test')).toBeInTheDocument();
   expect(await screen.findByText('No peer available at the moment')).toBeInTheDocument();
   expect(await screen.findByText('Home')).toBeInTheDocument();
   expect(await screen.findByText(/Foreign/i)).toBeInTheDocument();


### PR DESCRIPTION
## Description
This PR updates the home view so that now the clusters' names are displayed instead of their cluster-ids. Besides, hovering over the foreign cluster's name will prompt a tooltip showing the cluster-id. Also, the user's cluster name is displayed in the header of the home view.