### PR TITLE
Fix status home nodes not getting metrics

### DIFF
--- a/src/home/Status.js
+++ b/src/home/Status.js
@@ -143,8 +143,8 @@ function Status(props){
           let counter = 0;
           home_nodes.forEach(no => {
             _consumedHome = {
-              CPU: prev.CPU + convertCPU(no.usage.cpu),
-              RAM: prev.RAM + convertRAM(no.usage.memory)
+              CPU: _consumedHome.CPU + convertCPU(no.usage.cpu),
+              RAM: _consumedHome.RAM + convertRAM(no.usage.memory)
             }
             counter++;
             if(counter === home_nodes.length)


### PR DESCRIPTION
## Description
This little PR fixes a bug where the metrics from the metrics server for the home cluster were not considered, displaying the not precise ones. 