### PR TITLE
CRD list view - updated filters and code refactoring

### DIFF
--- a/src/CRD/CRDList.css
+++ b/src/CRD/CRDList.css
@@ -8,3 +8,12 @@
     max-width: 80%;
     margin: 0 auto 0;
 }
+
+.ant-table-filter-trigger-container {
+    width: 3em;
+    right: unset;
+}
+
+.ant-table-filter-trigger {
+    width: 3.5em;
+}

--- a/src/home/ConnectionDetails.js
+++ b/src/home/ConnectionDetails.js
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 import {
   Modal, Tabs, Typography, Tag, Badge, Space, Statistic,
-  Row, Col, Card, Progress, Input, Button, Table, Tooltip, Divider
+  Row, Col, Card, Progress, Table, Tooltip, Divider
 } from 'antd';
 import InfoCircleOutlined from '@ant-design/icons/lib/icons/InfoCircleOutlined';
 import HomeOutlined from '@ant-design/icons/lib/icons/HomeOutlined';
 import GlobalOutlined from '@ant-design/icons/lib/icons/GlobalOutlined';
 import { getColor } from './HomeUtils';
-import SearchOutlined from '@ant-design/icons/lib/icons/SearchOutlined';
 import ExclamationCircleTwoTone from '@ant-design/icons/lib/icons/ExclamationCircleTwoTone';
 import { getColumnSearchProps } from '../services/TableUtils';
 
@@ -62,13 +61,11 @@ function ConnectionDetails(props) {
 
     const column = [
       {
-        title: 'Name',
         dataIndex: 'Name',
         key: 'Name',
         ...getColumnSearchProps('Name', renderPODs)
       },
       {
-        title: 'Status',
         dataIndex: 'Status',
         key: 'Status',
         ...getColumnSearchProps('Status', renderPODs)
@@ -120,7 +117,6 @@ function ConnectionDetails(props) {
         },
       },
       {
-        title: 'Namespace',
         dataIndex: 'Namespace',
         key: 'Namespace',
         ...getColumnSearchProps('Namespace', renderPODs)

--- a/src/services/TableUtils.js
+++ b/src/services/TableUtils.js
@@ -57,5 +57,10 @@ export const getColumnSearchProps = (dataIndex, renderFunc) => ({
   },
   render: (text, record) => {
     return renderFunc(text, record, dataIndex);
+  },
+  title: () => {
+    return (
+      <div style={{marginLeft: '2em'}}>{dataIndex}</div>
+    )
   }
 });

--- a/test/CRDList.test.js
+++ b/test/CRDList.test.js
@@ -31,8 +31,12 @@ describe('CRD List', () => {
   test('Sidebar updates when a CRD is added/removed to favourites', async () => {
     await setup();
 
+    expect(await screen.findByLabelText('caret-down'));
+
     const favCRD = screen.getAllByLabelText('star')[2];
     userEvent.click(favCRD);
+
+    userEvent.click(await screen.findByLabelText('caret-down'));
 
     expect(await screen.findAllByText('Advertisement')).toHaveLength(2);
 


### PR DESCRIPTION
## Description
In this PR:
- code refactoring of CRD list view (from react class to function that use hooks)
- the position of the _search_ filter in the CRD table columns header is now beside the column it refers to;
- introduced a new _favourite_ filter, allowing the user to filter by favourite CRDs;
- introduced multiple filtering selection functions, allowing the user to use different filters together;

For example, here we see the CRDs filtered by group and by favourite.

![filtering-options](https://user-images.githubusercontent.com/38859529/93821421-d4784a80-fc5e-11ea-8832-17edb90ecaf0.png)


