### PR TITLE
Update cluster name to be easily editable

### DIFF
--- a/src/home/ListAvailable.js
+++ b/src/home/ListAvailable.js
@@ -64,7 +64,7 @@ function ListAvailable(props) {
 
     if(visibleA && visibleP){
       availablePeers.push(
-        <div key={fc.spec.clusterID}>
+        <div key={fc.spec.clusterIdentity.clusterID}>
           <AvailablePeer {...props} foreignCluster={fc}
                          refused={refused} reason={reason}
           />

--- a/src/home/ListConnected.js
+++ b/src/home/ListConnected.js
@@ -95,7 +95,7 @@ function ListConnected(props){
 
     if(client || server){
       connectedPeers.push(
-        <div key={fc.spec.clusterID}>
+        <div key={fc.spec.clusterIdentity.clusterID}>
           <ConnectedPeer {...props} incomingPods={incomingPods}
                          outgoingPods={outgoingPods}
                          foreignCluster={fc} client={client} server={server} />

--- a/test/Home.test.js
+++ b/test/Home.test.js
@@ -12,7 +12,6 @@ import AdvMockResponse from '../__mocks__/advertisement.json';
 import PRMockResponse from '../__mocks__/peeringrequest.json';
 import Error404 from '../__mocks__/404.json';
 import NodesMockResponse from '../__mocks__/nodes.json';
-import Error409 from '../__mocks__/409.json';
 import NodesMetricsMockResponse from '../__mocks__/nodes_metrics.json';
 import PodsMockResponse from '../__mocks__/pods.json';
 import { testTimeout } from '../src/constants';

--- a/test/LiqoHeader.test.js
+++ b/test/LiqoHeader.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+import { act, render, screen } from '@testing-library/react';
+import ApiManager from '../src/services/__mocks__/ApiManager';
+import { MemoryRouter } from 'react-router-dom';
+import { testTimeout } from '../src/constants';
+import CMMockResponse from '../__mocks__/configmap_clusterID.json';
+import ConfigMockResponse from '../__mocks__/configs.json';
+import LiqoHeader from '../src/home/LiqoHeader';
+import userEvent from '@testing-library/user-event';
+
+fetchMock.enableMocks();
+
+async function setup() {
+  window.api = new ApiManager({id_token: 'test'});
+  return render(
+      <MemoryRouter>
+        <LiqoHeader config={ConfigMockResponse.items[0]} />
+      </MemoryRouter>
+    )
+}
+
+function mocks(error){
+  fetch.mockResponse(req => {
+    if (req.url === 'http://localhost:3001/clustercustomobject/clusterconfigs') {
+      if(req.method === 'PUT'){
+        if(!error){
+          let config = ConfigMockResponse;
+          config.items[0].spec.discoveryConfig.clusterName = 'My cluster';
+          return Promise.resolve(new Response(JSON.stringify({body: config})));
+        } else
+          return Promise.reject();
+      }
+      else
+        return Promise.resolve(new Response(JSON.stringify({body: ConfigMockResponse})));
+    } else if (req.url === 'http://localhost:3001/configmaps/liqo') {
+      return Promise.resolve(new Response(JSON.stringify({body: CMMockResponse})));
+    }
+  })
+}
+
+async function changeClusterName(){
+  await setup();
+
+  const clusterName = await screen.findByText('LIQO');
+  const clusterID = await screen.findByText('10e3e821-8194-4fb1-856f-d917d2fc54c0');
+
+  expect(clusterName).toBeInTheDocument();
+  expect(clusterID).toBeInTheDocument();
+
+  userEvent.click(clusterName);
+  await userEvent.type(await screen.findByRole('textbox'),
+    '{backspace}{backspace}{backspace}{backspace}My cluster');
+  userEvent.click(clusterID);
+}
+
+describe('LiqoHeader', () => {
+  test('Error on saving clusterName', async () => {
+    mocks(true);
+
+    await changeClusterName();
+
+    expect(await screen.findByText('LIQO')).toBeInTheDocument();
+
+  }, testTimeout)
+
+  test('The header shows the cluster name and cluster ID', async () => {
+    mocks();
+
+    await changeClusterName();
+
+    expect(await screen.findByText('My cluster')).toBeInTheDocument();
+    expect(await screen.queryByText('LIQO')).not.toBeInTheDocument();
+
+  }, testTimeout)
+})

--- a/test/Status.test.js
+++ b/test/Status.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import fetchMock from 'jest-fetch-mock';
 import { act, render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import ViewMockResponse from '../__mocks__/views.json';
 import ApiManager from '../src/services/__mocks__/ApiManager';
 import { MemoryRouter } from 'react-router-dom';


### PR DESCRIPTION
## Description
This PR makes the cluster name editable right in the home view, without the need to go to modify it in the cluster config. Just clicking on it in the header of the home view will let you modify it. To save the changes, you can just press enter or click away. 

![edit clusterName](https://user-images.githubusercontent.com/38859529/94033130-f38eed80-fdc0-11ea-800d-00dba2c19008.png)
