### PR TITLE
Favourites and custom Icons

### DIFF
--- a/__mocks__/dashboardconf.json
+++ b/__mocks__/dashboardconf.json
@@ -154,46 +154,6 @@
           },
           {
             "favourite":true,
-            "icon":"AppstoreOutlined",
-            "render":{
-              "columns":[
-                {
-                  "columnContent":"param.metadata.name%//",
-                  "columnName":"Name"
-                },
-                {
-                  "columnContent":"param.metadata.namespace%//",
-                  "columnName":"Namespace"
-                }
-              ],
-              "tabs":[
-                {
-                  "tabContent":[
-                    {
-                      "cardContent":[
-                        {
-                          "parameter":"spec.containers"
-                        }
-                      ],
-                      "cardLayout":{
-                        "h":23,
-                        "w":11,
-                        "x":0,
-                        "y":0
-                      },
-                      "cardTitle":"Containers",
-                      "displayMode":"Table"
-                    }
-                  ],
-                  "tabName":"Summary"
-                }
-              ]
-            },
-            "resourceName":"Pod",
-            "resourcePath":"/api/v1/pods"
-          },
-          {
-            "favourite":true,
             "icon":"FileTextOutlined",
             "render":{
               "columns":[
@@ -211,7 +171,7 @@
                 }
               ]
             },
-            "resourceName":"CustomResourceDefinition",
+            "resourceName":"Custom Resources",
             "resourcePath":"/apis/apiextensions.k8s.io/v1/customresourcedefinitions"
           },
           {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -12,6 +12,19 @@ jest.mock('./src/templates/graph/GraphNet', () => {
   }
 });
 
+jest.mock('./src/resources/common/CustomIcon', () => {
+  const icons = require(`@ant-design/icons`);
+
+  const Icon = ({type}) => {
+    const Component = icons[type];
+    return <Component />;
+  }
+
+  return function CustomIcon(props) {
+    return (<Icon type={props.icon ? props.icon : 'ApiOutlined'}/>)
+  }
+})
+
 jest.mock('react-ace', () => {
   return ({ onChange }) => {
     return <input aria-label={'editor'} onChange={e => onChange(e.target.value)}/>

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -96,8 +96,8 @@ function App(props) {
     /** Get the CRDs at the start of the app */
     _api.getCRDs().
     then(() => {
-      _api.loadDashboardCRs('View');
       _api.loadDashboardCRs('DashboardConfig');
+      _api.loadDashboardCRs('View');
       window.api = _api;
       setApi(_api);
       message.success('Successfully logged in');

--- a/src/common/SideBar.css
+++ b/src/common/SideBar.css
@@ -38,3 +38,15 @@
         font-size: 20px;
     }
 }
+
+.ant-menu .ant-menu-submenu .ant-menu-submenu-title {
+    padding-left: 16px !important;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.ant-menu .ant-menu-submenu .ant-menu-item {
+    padding-left: 24px !important;
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/src/resources/common/CustomIcon.js
+++ b/src/resources/common/CustomIcon.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function CustomIcon(props){
+  const Icon = ({type, ...rest}) => {
+    const icons = require(`@ant-design/icons`);
+    const Component = icons[type];
+    return <Component {...rest} />;
+  }
+
+  return <Icon type={props.icon ? props.icon : 'ApiOutlined'} style={{fontSize: props.size}} />
+}

--- a/src/resources/common/DashboardConfigUtils.js
+++ b/src/resources/common/DashboardConfigUtils.js
@@ -1,10 +1,32 @@
-export function getResourceConfig(params){
-  if(window.api.dashConfigs.current){
+import _ from 'lodash';
+
+export const createNewConfig = (params, props, location) => {
+  return {
+    resourcePath: location.pathname,
+    resourceName: props.kind,
+    favourite: false,
+    render: {
+      columns: [
+        {
+          columnName: 'Name',
+          columnContent: 'param.metadata.name%//'
+        },
+        {
+          columnName: 'Namespace',
+          columnContent: 'param.metadata.namespace%//'
+        }
+      ]
+    }
+  }
+}
+
+export function getResourceConfig(params, location){
+  if(!_.isEmpty(window.api.dashConfigs.current)){
     let conf = window.api.dashConfigs.current.spec.resources.find(resource => {
-      return resource.resourcePath === window.location.pathname;
+      return resource.resourcePath === location.pathname;
     })
     if(!conf){
-      let path = '/' + window.location.pathname.split('/')[1] + '/' +
+      let path = '/' + location.pathname.split('/')[1] + '/' +
         (params.group ? params.group + '/' : '') +
         params.version + '/' +
         params.resource;
@@ -17,4 +39,34 @@ export function getResourceConfig(params){
     return conf;
   }
   return {};
+}
+
+export function updateResourceConfig(tempResourceConfig, params, location){
+  let CRD = window.api.getCRDFromKind('DashboardConfig');
+
+  /** The resource has a config, update it */
+  let path = '/' + location.pathname.split('/')[1] + '/' +
+    (params.group ? params.group + '/' : '') +
+    params.version + '/' +
+    params.resource;
+
+  let index = window.api.dashConfigs.current.spec.resources.indexOf(
+    window.api.dashConfigs.current.spec.resources.find(resource =>
+      resource.resourcePath === path
+    ))
+
+  if(index !== -1){
+    window.api.dashConfigs.current.spec.resources[index] = tempResourceConfig;
+  } else {
+    window.api.dashConfigs.current.spec.resources.push(tempResourceConfig);
+  }
+
+  window.api.updateCustomResource(
+    CRD.spec.group,
+    CRD.spec.version,
+    undefined,
+    CRD.spec.names.plural,
+    window.api.dashConfigs.current.metadata.name,
+    window.api.dashConfigs.current
+  ).catch(error => console.log(error))
 }

--- a/src/resources/common/buttons/FavouriteButton.js
+++ b/src/resources/common/buttons/FavouriteButton.js
@@ -1,0 +1,51 @@
+import { Rate } from 'antd';
+import React from 'react';
+import { useParams, useLocation } from 'react-router-dom';
+import { createNewConfig, getResourceConfig, updateResourceConfig } from '../DashboardConfigUtils';
+import _ from 'lodash';
+
+export default function FavouriteButton(props){
+  let params = useParams();
+  let location = useLocation();
+
+  /** Update DashboardConfig with the favourite resource */
+  const handleClickResourceListFav = () => {
+    if(!_.isEmpty(window.api.dashConfigs.current)){
+      let resourceConfig = getResourceConfig(params, location);
+
+      if(!_.isEmpty(resourceConfig)){
+        /** A config for this resource exists, update it */
+        resourceConfig.favourite = !resourceConfig.favourite;
+      } else {
+        /** A config for this resource does not exists, create one */
+        resourceConfig = createNewConfig(params, props, location);
+        resourceConfig.favourite = true;
+      }
+
+      updateResourceConfig(resourceConfig, params, location);
+    }
+  }
+
+
+  /** Update Resource with the 'favourite' annotation */
+  const handleClickResourceFav = () => {
+    let resource = props.resourceList.find(item => {return item.metadata.name === props.resourceName});
+    if(!resource.metadata.annotations || !resource.metadata.annotations.favourite){
+      resource.metadata.annotations = {favourite: 'true'};
+    } else {
+      resource.metadata.annotations.favourite = null;
+    }
+    return window.api.updateGenericResource(
+      resource.metadata.selfLink,
+      resource
+    ).catch(error => console.log(error));
+  }
+
+  return(
+    <Rate className="favourite-star" count={1}
+          value={props.favourite === 1 ? 1 : 0}
+          onChange={props.list ? handleClickResourceListFav : handleClickResourceFav}
+          style={props.list ? {marginLeft: 10} : {marginLeft: 0, marginTop: -16}}
+    />
+  )
+}

--- a/src/resources/common/buttons/IconButton.js
+++ b/src/resources/common/buttons/IconButton.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Input, List, Modal, Tooltip, Typography } from 'antd';
+import { splitCamelCaseAndUp } from '../../../services/stringUtils';
+import {SearchOutlined} from '@ant-design/icons';
+import { useParams } from 'react-router-dom';
+import CustomIcon from '../CustomIcon';
+
+export default function IconButton(props){
+  let params = useParams();
+
+  const [icons, setIcons] = useState([])
+  const totalIcons = useRef([]);
+
+  useEffect(() => {
+    const iconsArray = [];
+    const _icons = require(`@ant-design/icons`);
+    for(let key in _icons){
+      if(_icons.hasOwnProperty(key)){
+        if(key !== 'setTwoToneColor' &&
+          key !== 'getTwoToneColor' &&
+          key !== 'createFromIconfontCN' &&
+          key.includes('Outlined')
+        ){
+          iconsArray.push({
+            key: key,
+            icon: (<div key={key}>
+              <Button onClick={() => {
+                        props.setIcon(key);
+                        setIcons(totalIcons.current);
+                      }}
+                      style={{ width: '7em', height: '7em', border: 'none', boxShadow: 'none' }}
+                      icon={<CustomIcon icon={key} size={32} />}
+              />
+              <div style={{ textAlign: 'center' }}>
+                <Typography.Text strong >
+                  {splitCamelCaseAndUp(key).replace(' Outlined', '')}
+                </Typography.Text>
+              </div>
+            </div>)
+          })
+        }
+      }
+    }
+
+    setIcons(iconsArray);
+    totalIcons.current = iconsArray;
+  }, [params]);
+
+  const onChange = (value) => {
+    let searched = totalIcons.current.filter(icon => icon.key.toUpperCase()
+      .includes(value.toUpperCase().replace(' ', '')));
+    setIcons(searched);
+  }
+
+  return(
+    <Modal title={'Icons'}
+           centered
+           footer={null}
+           visible={props.onAddIcon}
+           onCancel={() => {
+             setIcons(totalIcons.current);
+             props.setOnAddIcon(false);
+           }}
+           destroyOnClose
+    >
+      <div style={{height: '70vh', overflow: 'auto'}}>
+        <div style={{marginBottom: 4}}>
+          <Input
+            role={'input'}
+            placeholder="Search icon"
+            suffix={
+              <SearchOutlined style={{ color: 'rgba(0,0,0,.45)' }} />
+            }
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </div>
+        <List
+          grid={{ gutter: 0, column: 4 }}
+          dataSource={icons}
+          renderItem={item => (
+            <div>{item.icon}</div>
+          )}
+          pagination={{
+            showSizeChanger: false,
+            pageSize: 16,
+          }}
+        />
+      </div>
+    </Modal>
+  )
+}
+

--- a/src/resources/resource/ResourceGeneral.js
+++ b/src/resources/resource/ResourceGeneral.js
@@ -88,7 +88,7 @@ function ResourceGeneral(props){
 
   const getDashConfig = () => {
     setResourceConfig(() => {
-      return getResourceConfig(params);
+      return getResourceConfig(params, location);
     });
   }
 

--- a/src/resources/resource/ResourceHeader.js
+++ b/src/resources/resource/ResourceHeader.js
@@ -11,6 +11,7 @@ import {
   DragOutlined, PushpinOutlined, DeleteOutlined
 } from '@ant-design/icons';
 import ResourceBreadcrumb from '../common/ResourceBreadcrumb';
+import FavouriteButton from '../common/buttons/FavouriteButton';
 
 function ResourceHeader(props) {
   const [isPinned, setIsPinned] = useState(false);
@@ -68,6 +69,16 @@ function ResourceHeader(props) {
                     <LoadingOutlined />)
                   </div>
                 ) : null}
+              </Col>
+              <Col>
+                <span style={{marginLeft: 10}}>
+                  <FavouriteButton resourceName={props.resource.metadata.name}
+                                   favourite={(props.resource.metadata.annotations &&
+                                     props.resource.metadata.annotations.favourite) ? 1 : 0
+                                   }
+                                   resourceList={[props.resource]}
+                  />
+                </span>
               </Col>
             </Row>
           </Col>

--- a/src/resources/resourceList/ResourceList.js
+++ b/src/resources/resourceList/ResourceList.js
@@ -7,6 +7,7 @@ import { resourceNotifyEvent } from '../common/ResourceUtils';
 import { renderResourceList } from './ResourceListRenderer';
 import { calculateAge } from '../../services/TimeUtils';
 import { getResourceConfig } from '../common/DashboardConfigUtils';
+import FavouriteButton from '../common/buttons/FavouriteButton';
 
 function ResourceList(props) {
   /**
@@ -40,6 +41,7 @@ function ResourceList(props) {
     return () => {
       setLoading(true);
       setResourceList([]);
+      setResourceConfig({});
       setColumnsContents([]);
       setColumnHeaders([]);
       window.api.abortWatch(params.resource);
@@ -59,6 +61,23 @@ function ResourceList(props) {
     let columns = [];
 
     columns.push(
+      {
+        title: '',
+        fixed: 'left',
+        dataIndex: 'Favourite',
+        width: '1em',
+        sortDirections: ['descend'],
+        align: 'center',
+        ellipsis: true,
+        sorter: {
+          compare: (a, b) => a.Favourite - b.Favourite,
+        },
+        render: (text, record) => (
+          <FavouriteButton favourite={text} resourceList={resourceList}
+                           resourceName={record.Name}
+          />
+        )
+      },
       {
         dataIndex: 'Name',
         key: 'Name',
@@ -101,8 +120,14 @@ function ResourceList(props) {
 
     const resourceViews = [];
     resourceList.forEach(resource => {
+      let favourite = 0;
+      if(resource.metadata.annotations){
+        if(resource.metadata.annotations.favourite)
+          favourite = 1;
+      }
       let object = {
         key: resource.metadata.name + '_' + resource.metadata.namespace,
+        Favourite: favourite,
         Age: calculateAge(resource.metadata.creationTimestamp)
       };
 
@@ -117,7 +142,7 @@ function ResourceList(props) {
 
   const getDashConfig = () => {
     setResourceConfig(() => {
-      return getResourceConfig(params);
+      return getResourceConfig(params, location);
     });
   }
 

--- a/src/services/api/ApiInterface.js
+++ b/src/services/api/ApiInterface.js
@@ -11,7 +11,7 @@ export default function ApiInterface(_user, props) {
 
   const CRDs = {current: []};
   const customViews = {current: []};
-  const dashConfigs = {current: null};
+  const dashConfigs = {current: {}};
   const namespace = {current: null};
   const watches = {current: []};
   /** Callback for the autocomplete search bar */
@@ -117,12 +117,11 @@ export default function ApiInterface(_user, props) {
             if(res.body.items[0]){
               dashConfigs.current = res.body.items[0];
               /** update CDs in the views */
-              manageCallbackDCs(dashConfigs.current);
+              manageCallbackDCs();
             } else {
               /** If there is no config, create one */
               createNewDC(CRD);
             }
-
             /** Then set up a watch to watch changes in the CR of the CRD */
             watchResource(
               'apis',
@@ -135,7 +134,7 @@ export default function ApiInterface(_user, props) {
           }else{
             customViews.current = res.body.items;
             /** update CVs in the views */
-            manageCallbackCVs(customViews.current);
+            manageCallbackCVs();
 
             /** Then set up a watch to watch changes in the CR of the CRD */
             watchResource(
@@ -167,7 +166,7 @@ export default function ApiInterface(_user, props) {
     ).then(res => {
       dashConfigs.current = res.body;
       /** update CDs in the views */
-      manageCallbackDCs(dashConfigs.current);
+      manageCallbackDCs();
     })
   }
 
@@ -441,7 +440,7 @@ export default function ApiInterface(_user, props) {
 
   const DCsNotifyEvent = (type, object) => {
     if (type === 'MODIFIED') {
-      dashConfigs.current = object.items[0];
+      dashConfigs.current = object;
       message.success('Dashboard Config modified');
       manageCallbackDCs();
     } else if (type === 'DELETED') {

--- a/src/services/api/__mocks__/ApiManager.js
+++ b/src/services/api/__mocks__/ApiManager.js
@@ -56,11 +56,17 @@ export default function ApiManager() {
       plural === 'foreignclusters' ||
       plural === 'searchdomains' ||
       plural === 'advertisements' ||
+      plural === 'dashboardconfigs' ||
       plural === 'views') {
       return fetch('http://localhost:3001/clustercustomobject/' + plural, { method: 'PUT', body: item })
         .then(res => res.json())
         .then((res) => {
           if(plural === 'views') {
+            let itemDC = JSON.parse(JSON.stringify(item));
+            itemDC.metadata.resourceVersion++;
+            watchList.find(item => item.plural === (plural + '/')).callback('MODIFIED', itemDC);
+            return Promise.resolve(new Response(JSON.stringify(item)))
+          } else if(plural === 'dashboardconfigs') {
             let itemDC = JSON.parse(JSON.stringify(item));
             itemDC.metadata.resourceVersion++;
             watchList.find(item => item.plural === (plural + '/')).callback('MODIFIED', itemDC);

--- a/test/APIGroupList.test.js
+++ b/test/APIGroupList.test.js
@@ -65,7 +65,6 @@ function mocks(errorApis, errorApi){
         return Promise.resolve(new Response(JSON.stringify(ApiV1MockResponse)));
     } else if (url === 'http://localhost:3001/apis/') {
       if(errorApis) {
-        console.log('hello')
         return Promise.reject(Error401.body);
       }
       else
@@ -94,7 +93,7 @@ describe('APIGroupList', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Api')).toBeInTheDocument();
+    expect(await screen.findByText(/Api v1/i)).toBeInTheDocument();
     expect(await screen.findByText('Apis')).toBeInTheDocument();
 
     userEvent.click(await screen.findByText('Apis'));
@@ -104,7 +103,7 @@ describe('APIGroupList', () => {
     userEvent.click(await screen.findByText('apis'));
     userEvent.click(await screen.findByLabelText('home'));
 
-    userEvent.click(await screen.findByText('Api'));
+    userEvent.click(await screen.findByText(/Api v1/i));
     expect(await screen.findByText('pods')).toBeInTheDocument();
     userEvent.click(await screen.findByText('pods'));
     expect(await screen.findByText('Pod')).toBeInTheDocument();

--- a/test/CRD.test.js
+++ b/test/CRD.test.js
@@ -120,9 +120,9 @@ async function alwaysPresent(kind, descr) {
   expect(await screen.findByLabelText('crd')).toBeInTheDocument();
   expect(screen.getByText(kind)).toBeInTheDocument();
   expect(screen.getByText(descr)).toBeInTheDocument();
-  expect(screen.getAllByLabelText('star')).toHaveLength(3);
+  expect(screen.getAllByLabelText('star')).toHaveLength(4);
   expect(screen.getByText('Annotations')).toBeInTheDocument();
-  expect(screen.getByText('Resources')).toBeInTheDocument();
+  expect(screen.getAllByText('Resources')).toHaveLength(2);
   expect(screen.getByText('Schema')).toBeInTheDocument();
   expect(screen.getAllByLabelText('layout')).toHaveLength(2);
   expect(screen.getByLabelText('picture')).toBeInTheDocument();
@@ -537,7 +537,9 @@ describe('CRD', () => {
     await setup_only_CRD(false, false, true);
 
     expect(await screen.findByText('LiqoDashTest')).toBeInTheDocument();
-    userEvent.click(await screen.findByText('Resources'));
+
+    let resources = await screen.findAllByText('Resources');
+    userEvent.click(resources[1]);
 
     act(() => {
       window.api.apiManager.current.sendModifiedSignal('liqodashtests', LiqoDashMockResponse.items[0])

--- a/test/DashboardConfig.test.js
+++ b/test/DashboardConfig.test.js
@@ -63,7 +63,7 @@ describe('DashboardConfig', () => {
 
     let apiManager = window.api.apiManager.current;
 
-    let dashConf = DashboardConfig;
+    let dashConf = DashboardConfig.items[0];
 
     dashConf.metadata.resourceVersion += 1;
 

--- a/test/FavouriteAndIcon.test.js
+++ b/test/FavouriteAndIcon.test.js
@@ -1,0 +1,249 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { testTimeout } from '../src/constants';
+import { generalMocks, loginTest, mockCRDAndViewsExtended } from './RTLUtils';
+import Cookies from 'js-cookie';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../src/app/App';
+import React from 'react';
+import fetchMock from 'jest-fetch-mock';
+import Error401 from '../__mocks__/401.json';
+
+fetchMock.enableMocks();
+
+jest.mock('../src/services/api/ApiManager');
+
+async function setup() {
+  mockCRDAndViewsExtended();
+  await loginTest();
+
+  const customview = screen.getByText('Custom Resources');
+  userEvent.click(customview);
+
+  expect(await screen.findByText(/advertisement/i)).toBeInTheDocument();
+
+  expect(screen.getAllByRole('row')).toHaveLength(10);
+}
+
+function mocks(errorPATCH, errorPUT){
+  fetch.mockResponse(req => {
+    if(req.method === 'PATCH' && errorPATCH){
+      return Promise.reject();
+    } else if(req.method === 'PUT' && errorPUT){
+      return Promise.reject(Error401.body);
+    }
+    else if(req.method === 'DELETE' && req.url === 'http://localhost/apiserver/api/v1/namespaces/test/pods/hello-world-deployment-6756549f5-x66v9'){
+      if(!error)
+        return Promise.resolve(new Response(JSON.stringify('')));
+      else
+        return Promise.reject();
+    }
+    else if(generalMocks(req.url))
+      return generalMocks(req.url);
+  })
+}
+
+beforeEach(() => {
+  Cookies.remove('token');
+});
+
+describe('Favourites and Icons', () => {
+  test('Sidebar updates when a resource is added/removed to favourites', async () => {
+    await setup();
+
+    expect(await screen.findAllByLabelText('caret-down'));
+
+    let stars = await screen.findAllByLabelText('star');
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.queryByText('Custom Resources')).not.toBeInTheDocument();
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.queryByText('Custom Resources')).toBeInTheDocument();
+
+    userEvent.click(stars[4]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    userEvent.click(stars[4]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+  }, testTimeout)
+
+  test('Sidebar and List update icons', async () => {
+    await setup();
+
+    expect(await screen.findAllByLabelText('caret-down'));
+
+    let icons = await screen.findAllByLabelText('file-text');
+
+    userEvent.click(icons[1]);
+
+    expect(await screen.findByText('Icons'));
+
+    const textbox = await screen.findByRole('input');
+
+    await userEvent.type(textbox, 'fileadd');
+
+    expect(await screen.findByLabelText('file-add')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByLabelText('file-add'));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.findAllByLabelText('file-add')).toHaveLength(2);
+
+  }, testTimeout)
+
+  test('Close icons modal', async () => {
+    await setup();
+
+    expect(await screen.findAllByLabelText('caret-down'));
+
+    let icons = await screen.findAllByLabelText('file-text');
+
+    userEvent.click(icons[1]);
+
+    expect(await screen.findByLabelText('close')).toBeInTheDocument();
+    userEvent.click(await screen.findByLabelText('close'));
+    expect(await screen.queryByText('Icons')).not.toBeInTheDocument();
+
+  }, testTimeout)
+
+  test('Error on favourites (resource)', async () => {
+    mocks(true);
+
+    await loginTest();
+
+    const customview = screen.getByText('Custom Resources');
+    userEvent.click(customview);
+
+    expect(await screen.findAllByLabelText('caret-down'));
+
+    let stars = await screen.findAllByLabelText('star');
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.queryByText('Custom Resources')).not.toBeInTheDocument();
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.queryByText('Custom Resources')).toBeInTheDocument();
+
+    userEvent.click(stars[4]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+  }, testTimeout)
+
+  test('Error on favourites (config)', async () => {
+    mocks(true, true);
+
+    await loginTest();
+
+    const customview = screen.getByText('Custom Resources');
+    userEvent.click(customview);
+
+    expect(await screen.findAllByLabelText('caret-down'));
+
+    let stars = await screen.findAllByLabelText('star');
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.findByText('Custom Resources')).toBeInTheDocument();
+
+  }, testTimeout)
+
+  test('Manage favourites when resource not in the config', async () => {
+    mocks();
+
+    Cookies.set('token', 'password');
+    window.history.pushState({}, 'Page Title', '/api/v1/pods');
+
+    render(
+      <MemoryRouter>
+        <App/>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Pod')).toBeInTheDocument();
+
+    let stars = await screen.findAllByLabelText('star');
+
+    userEvent.click(stars[2]);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.findAllByText('Pod')).toHaveLength(2);
+
+  }, testTimeout)
+
+  test('Manage icons when resource not in the config', async () => {
+    mocks();
+
+    Cookies.set('token', 'password');
+    window.history.pushState({}, 'Page Title', '/api/v1/pods');
+
+    render(
+      <MemoryRouter>
+        <App/>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Pod')).toBeInTheDocument();
+
+    let icons = await screen.findAllByLabelText('api');
+
+    userEvent.click(icons[2]);
+
+    expect(await screen.findByText('Icons'));
+
+    const textbox = await screen.findByRole('input');
+
+    await userEvent.type(textbox, 'fileadd');
+
+    expect(await screen.findByLabelText('file-add')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByLabelText('file-add'));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1000));
+    })
+
+    expect(await screen.findByLabelText('file-add')).toBeInTheDocument();
+
+  }, testTimeout)
+})

--- a/test/ResourceList.test.js
+++ b/test/ResourceList.test.js
@@ -7,11 +7,9 @@ import userEvent from '@testing-library/user-event';
 import CRDmockResponse from '../__mocks__/crd_fetch_long.json';
 import CRDmockEmpty from '../__mocks__/crd_empty.json';
 import ViewMockResponse from '../__mocks__/views.json';
-import ApiInterface from '../src/services/api/ApiInterface';
 import { MemoryRouter } from 'react-router-dom';
 import { testTimeout } from '../src/constants';
 import Cookies from 'js-cookie';
-import ResourceList from '../src/resources/resourceList/ResourceList';
 import App from '../src/app/App';
 import NamespaceResponse from '../__mocks__/namespaces.json';
 import NodesMockResponse from '../__mocks__/nodes.json';
@@ -38,31 +36,12 @@ beforeEach(() => {
 });
 
 describe('Resource List', () => {
-  /*test('Sidebar updates when a resource is added/removed to favourites', async () => {
-    await setup();
-
-    expect(await screen.findByLabelText('caret-down'));
-
-    const favCRD = screen.getAllByLabelText('star')[2];
-    userEvent.click(favCRD);
-
-    userEvent.click(await screen.findByLabelText('caret-down'));
-
-    expect(await screen.findAllByText('Advertisement')).toHaveLength(2);
-
-    userEvent.click(favCRD);
-
-    expect(screen.findByText('Advertisement'));
-  }, testTimeout)*/
-
   test('CRD list is correctly paginated and updated when page is changed', async () => {
     fetch.mockImplementation((url) => {
       if (url === 'http://localhost:3001/customresourcedefinition') {
         return Promise.resolve(new Response(JSON.stringify(CRDmockResponse)))
       } else if (url === 'http://localhost:3001/clustercustomobject/views') {
         return Promise.resolve(new Response(JSON.stringify({body: ViewMockResponse})))
-      } else if (url === 'http://localhost:3001/clustercustomobject/dashboardconfigs') {
-        return Promise.reject(Error404.body);
       } else if(alwaysPresentGET(url)){
         return alwaysPresentGET(url)
       } else {
@@ -82,6 +61,27 @@ describe('Resource List', () => {
     userEvent.click(screen.getByText('2'));
 
     expect(await screen.findAllByRole('row')).toHaveLength(3);
+
+  }, testTimeout)
+
+  test('404 on dashboardconfig', async () => {
+    fetch.mockImplementation((url) => {
+      if (url === 'http://localhost:3001/customresourcedefinition') {
+        return Promise.resolve(new Response(JSON.stringify(CRDmockResponse)))
+      } else if (url === 'http://localhost:3001/clustercustomobject/views') {
+        return Promise.resolve(new Response(JSON.stringify({body: ViewMockResponse})))
+      } else if (url === 'http://localhost:3001/clustercustomobject/dashboardconfigs') {
+        return Promise.reject(Error404.body);
+      } else if(alwaysPresentGET(url)){
+        return alwaysPresentGET(url)
+      } else {
+        return generalHomeGET(url);
+      }
+    })
+
+    await loginTest();
+
+    expect(await screen.queryByText('Custom Resources')).not.toBeInTheDocument();
 
   }, testTimeout)
 


### PR DESCRIPTION
## Description
With this PR the user can mark a resource (list or single resource) as favourite and it will be displayed accordingly in the related views. Resource's kinds marked as favourite (deployments, pods, CRDs...) will also pop up in the sidebar for easy access. Single resources marked as favourite can be filtered in the resource list view.
Also added support for icon customization on resource list views and sidebar favourites. When no icon is selected will be used the default icon.