### PR TITLE
Header search autocomplete bug fix

### DIFF
--- a/src/common/ResourceAutocomplete.js
+++ b/src/common/ResourceAutocomplete.js
@@ -1,5 +1,6 @@
-import { AutoComplete, Select } from 'antd';
+import { Select } from 'antd';
 import React, { useEffect, useState } from 'react';
+import Utils from '../services/Utils';
 
 export function ResourceAutocomplete(props){
   const [autocomplete, setAutocomplete] = useState([]);
@@ -20,10 +21,14 @@ export function ResourceAutocomplete(props){
                 label: resource.name
               })
           });
-          setAutocomplete(prev => [...prev, {
-            label: group.name,
-            options: tempRes
-          }])
+          setAutocomplete(prev => {
+            if(!prev.find(item => Utils().arraysEqual(item.options, tempRes)))
+              return [...prev, {
+                label: group.name,
+                options: tempRes
+              }];
+            else return prev;
+          })
         })
       })
     }).catch(error => console.log(error))
@@ -38,10 +43,14 @@ export function ResourceAutocomplete(props){
               label: resource.name
             })
         })
-        setAutocomplete(prev => [...prev, {
-          label: 'api',
-          options: tempRes
-        }])
+        setAutocomplete(prev => {
+          if(!prev.find(item => Utils().arraysEqual(item.options, tempRes)))
+            return [...prev, {
+              label: 'api',
+              options: tempRes
+            }]
+          else return prev;
+        })
       }).catch(error => console.log(error));
   }
 

--- a/src/services/Utils.js
+++ b/src/services/Utils.js
@@ -134,6 +134,22 @@ export default function Utils() {
     return origResource;
   }
 
+  function arraysEqual(a, b) {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (a.length !== b.length) return false;
+
+    a.sort();
+    b.sort();
+
+    for (let i = 0; i < a.length; ++i) {
+      if(!_.isEqual(a[i], b[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   return{
     setRealProperties,
     OAPIV3toJSONSchema,
@@ -141,5 +157,6 @@ export default function Utils() {
     getSelectedProperties,
     fromDotToObject,
     replaceObject,
+    arraysEqual,
   }
 }


### PR DESCRIPTION
### Description
This PR fix a minor bug where if two CRDs are updated at the same time, triggering the update of the resources shown in the autocomplete search in the header, that would lead to some of these resources doubled in the autocomplete search dropdown.