### PR TITLE
Switchable language in editor (YAML or JSON)

### DIFF
--- a/src/editors/Editor.js
+++ b/src/editors/Editor.js
@@ -1,24 +1,33 @@
 import AceEditor from 'react-ace';
-import { Button, message } from 'antd';
+import { Button, Card, message } from 'antd';
 import React, { useEffect, useState } from 'react';
 import YAML from 'yaml';
 import 'ace-builds/webpack-resolver';
 import 'ace-builds/src-noconflict/mode-json';
+import 'ace-builds/src-noconflict/mode-yaml';
 import 'ace-builds/src-noconflict/theme-dawn';
 
 export default function Editor(props){
-  const [value, setValue] = useState('');
+  const initValue = {metadata: {name: ''}};
+  const [value, setValue] = useState(JSON.stringify(initValue, null, 2));
+  const [valueYAML, setValueYAML] = useState(YAML.stringify(initValue));
+  const [currentTab, setCurrentTab] = useState('YAML');
 
   const onClick = () => {
     let item;
 
-    try {
-      item = JSON.parse(value);
-    } catch(error) {
+    if(currentTab === 'YAML'){
       try {
-        item = YAML.parse(value);
+        item = YAML.parse(valueYAML);
       } catch(error){
-        message.error('JSON or YAML not valid');
+        message.error('YAML not valid');
+        return;
+      }
+    } else {
+      try {
+        item = JSON.parse(value);
+      } catch(error){
+        message.error('JSON not valid');
         return;
       }
     }
@@ -27,37 +36,65 @@ export default function Editor(props){
   }
 
   useEffect(() => {
-    setValue(props.value ? props.value : '');
+    setValue(props.value ? props.value : JSON.stringify(initValue, null, 2));
+    setValueYAML(props.value ? YAML.stringify(JSON.parse(props.value)) : YAML.stringify(initValue));
   }, [props.value])
 
   const onChange = (value) => {
-    setValue(value);
+    if(currentTab === 'YAML') {
+      setValueYAML(value);
+      try{
+        setValue(JSON.stringify(YAML.parse(value), null, 2));
+      }catch{}
+    } else {
+      setValue(value);
+      try{
+        setValueYAML(YAML.stringify(JSON.parse(value)));
+      }catch{}
+    }
   }
 
   return (
     <div>
-      <AceEditor
-        mode={'json'}
-        theme="dawn"
-        fontSize={16}
-        value={value}
-        readOnly={!props.onClick}
-        placeholder={props.placeholder}
-        onChange={props.onClick ? onChange : null}
-        highlightActiveLine
-        showLineNumbers
-        tabSize={2}
-        height={'72vh'}
-        width={'auto'}
-        setOptions={{
-          useWorker: false
-        }}
-      />
-      {props.onClick ? (
-        <div style={{marginTop: 20}}>
-          <Button type={'primary'} onClick={onClick} style={{width: "20%"}}>Save</Button>
-        </div>
-      ) : null}
+      <Card tabList={[{
+              key: 'YAML',
+              tab: 'YAML'
+            }, {
+              key: 'JSON',
+              tab: 'JSON'
+            }]}
+            tabProps={{
+              size: 'small',
+            }}
+            size={'small'}
+            type={'inner'}
+            activeTabKey={currentTab}
+            onTabChange={key => {setCurrentTab(key)}}
+            style={{overflow: 'hidden'}}
+      >
+        <AceEditor
+          mode={currentTab === 'YAML' ? 'yaml' : 'json'}
+          theme="dawn"
+          fontSize={16}
+          value={currentTab === 'YAML' ? valueYAML : value}
+          readOnly={!props.onClick}
+          placeholder={props.placeholder}
+          onChange={props.onClick ? onChange : null}
+          highlightActiveLine
+          showLineNumbers
+          tabSize={2}
+          height={'62vh'}
+          width={'auto'}
+          setOptions={{
+            useWorker: false
+          }}
+        />
+        {props.onClick ? (
+          <div style={{marginTop: 20}}>
+            <Button type={'primary'} onClick={onClick} style={{width: "20%"}}>Save</Button>
+          </div>
+        ) : null}
+      </Card>
     </div>
   )
 }

--- a/src/resources/resource/ResourceGeneral.js
+++ b/src/resources/resource/ResourceGeneral.js
@@ -144,7 +144,7 @@ function ResourceGeneral(props){
         </div>
       ),
       JSON: (
-        <div style={{padding: 12}}>
+        <div>
           <Editor value={JSON.stringify(resource[0], null, 2)}
                   onClick={submit}
           />

--- a/test/NewResource.test.js
+++ b/test/NewResource.test.js
@@ -168,6 +168,8 @@ describe('NewResource', () => {
 
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[0]);
 
     await userEvent.type(screen.getByLabelText('editor'), '{"name": "test", "namespace": "test"}');
 
@@ -181,6 +183,8 @@ describe('NewResource', () => {
 
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[0]);
 
     await userEvent.type(screen.getByLabelText('editor'), 'name: "test", {"namespace" test');
 
@@ -195,6 +199,8 @@ describe('NewResource', () => {
     userEvent.click(screen.getByLabelText('plus'));
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[2]);
 
     await userEvent.type(screen.getByLabelText('editor'), JSON.stringify(LiqoDashNewMockResponse));
 
@@ -284,6 +290,8 @@ describe('NewResource', () => {
     userEvent.click(screen.getByLabelText('plus'));
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[2]);
 
     await userEvent.type(screen.getByLabelText('editor'), JSON.stringify(LiqoDashNewMockResponse));
 

--- a/test/UpdateCR.test.js
+++ b/test/UpdateCR.test.js
@@ -64,6 +64,8 @@ describe('UpdateCR', () => {
     userEvent.click(screen.getAllByLabelText('edit')[1]);
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[2]);
 
     await userEvent.type(screen.getByLabelText('editor'), JSON.stringify(LiqoDashUpdatedMockResponse));
 
@@ -92,18 +94,36 @@ describe('UpdateCR', () => {
     expect(textboxes[3]).toHaveAttribute('value', 'purple');
   }, testTimeout)
 
-  test('Editor throws error when not valid body', async () => {
+  test('Editor throws error when not valid body (YAML)', async () => {
     await setup_resource();
 
     userEvent.click(screen.getAllByLabelText('edit')[1]);
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const YAML = await screen.findAllByText('YAML');
+    userEvent.click(YAML[0]);
+
+    await userEvent.type(screen.getByLabelText('editor'), 'item: [cost: 11:: _name: green]');
+
+    userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+    expect(await screen.findByText('YAML not valid')).toBeInTheDocument();
+  }, testTimeout)
+
+  test('Editor throws error when not valid body (JSON)', async () => {
+    await setup_resource();
+
+    userEvent.click(screen.getAllByLabelText('edit')[1]);
+    expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
+    userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[2]);
 
     await userEvent.type(screen.getByLabelText('editor'), '{"item": [{"cost": 11 "name": "green"}]}');
 
     userEvent.click(screen.getByRole('button', {name: 'Save'}));
 
-    expect(await screen.findByText('JSON or YAML not valid')).toBeInTheDocument();
+    expect(await screen.findByText('JSON not valid')).toBeInTheDocument();
   }, testTimeout)
 
   test('Error notification when 409', async () => {
@@ -112,6 +132,8 @@ describe('UpdateCR', () => {
     userEvent.click(screen.getAllByLabelText('edit')[1]);
     expect(await screen.findByText('JSON/YAML')).toBeInTheDocument();
     userEvent.click(screen.getByText('JSON/YAML'));
+    const _JSON = await screen.findAllByText('JSON');
+    userEvent.click(_JSON[2]);
 
     await userEvent.type(screen.getByLabelText('editor'), JSON.stringify(LiqoDashUpdatedMockResponse));
 


### PR DESCRIPTION
### Description
This PR adds the possibility to choose between YAML or JSON in the editor used to create/update resources, while so far only the JSON option was given.