### PR TITLE
Add resizable column width on table

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,11 @@
     "react-ace": "^9.2.1",
     "react-color": "^2.19.3",
     "react-css-theme-switcher": "^0.2.2",
+    "react-drag-listview": "^0.1.8",
     "react-github-btn": "^1.2.0",
     "react-grid-layout": "^1.2.0",
+    "react-measure": "^2.5.2",
+    "react-resizable": "^1.11.0",
     "react-resize-detector": "^5.2.0",
     "yaml": "^1.10.0"
   },

--- a/src/app/CR.css
+++ b/src/app/CR.css
@@ -32,3 +32,23 @@
 .ant-collapse-content .ant-collapse-content-box {
     padding: 8px 12px !important;
 }
+
+.react-resizable {
+    position: relative;
+    background-clip: padding-box;
+}
+
+.react-resizable-handle {
+    position: absolute;
+    width: 10px;
+    height: 100%;
+    bottom: 0;
+    right: -5px;
+    cursor: col-resize;
+    z-index: 1;
+}
+
+.dragHandler:hover {
+    cursor: move;
+    background-color: #ccc;
+}

--- a/src/resources/APIResourceList/APIResourceList.js
+++ b/src/resources/APIResourceList/APIResourceList.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Typography, Table } from 'antd';
 import { Link, withRouter, useLocation } from 'react-router-dom';
-import { getColumnSearchProps } from '../../services/TableUtils';
+import { getColumnSearchProps, ResizableTitle } from '../../services/TableUtils';
 import ListHeader from '../resourceList/ListHeader';
 import ErrorRedirect from '../../error-handles/ErrorRedirect';
 
@@ -9,6 +9,7 @@ function APIResourceList() {
   /**
    * @param: loading: boolean
    */
+  const [columns, setColumns] = useState([])
   const [error, setError] = useState();
   const [loading, setLoading] = useState(true);
   const [APIResourceList, setAPIResourceList] = useState([]);
@@ -19,6 +20,29 @@ function APIResourceList() {
   useEffect(() => {
     loadAPIResourceList();
   }, []);
+
+  useEffect(() => {
+    if(APIResourceList.length > 0){
+      setColumns([{
+        dataIndex: 'Name',
+        key: 'Name',
+        title: <div style={{marginLeft: '2em'}}>Name</div>,
+        ...getColumnSearchProps('Name', renderAPIResourceList, setColumns)
+      },
+        {
+          dataIndex: 'Kind',
+          key: 'Kind',
+          title: <div style={{marginLeft: '2em'}}>Kind</div>,
+          ...getColumnSearchProps('Kind', renderAPIResourceList, setColumns)
+        },
+        {
+          dataIndex: 'Namespaced',
+          key: 'Namespaced',
+          title: <div style={{marginLeft: '2em'}}>Namespaced</div>,
+          ...getColumnSearchProps('Namespaced', renderAPIResourceList)
+        }])
+    }
+  }, [APIResourceList])
 
   const loadAPIResourceList = () => {
     window.api.getGenericResource(location.pathname)
@@ -64,27 +88,6 @@ function APIResourceList() {
     });
   });
 
-  const columns = [
-    {
-      dataIndex: 'Name',
-      key: 'Name',
-      title: <div style={{marginLeft: '2em'}}>Name</div>,
-      ...getColumnSearchProps('Name', renderAPIResourceList)
-    },
-    {
-      dataIndex: 'Kind',
-      key: 'Kind',
-      title: <div style={{marginLeft: '2em'}}>Kind</div>,
-      ...getColumnSearchProps('Kind', renderAPIResourceList)
-    },
-    {
-      dataIndex: 'Namespaced',
-      key: 'Namespaced',
-      title: <div style={{marginLeft: '2em'}}>Namespaced</div>,
-      ...getColumnSearchProps('Namespaced', renderAPIResourceList)
-    },
-  ]
-
   if(error)
     return <ErrorRedirect match={{params: {statusCode: error}}} />
 
@@ -92,10 +95,16 @@ function APIResourceList() {
     <div>
       <ListHeader kind={kind} />
       <Table columns={columns} dataSource={APIResourceViews}
+             components={{
+               header: {
+                 cell: ResizableTitle
+               }
+             }}
              pagination={{ position: ['bottomCenter'],
                hideOnSinglePage: APIResourceViews < 11,
                showSizeChanger: true,
              }} showSorterTooltip={false}
+             bordered
              loading={loading}
       />
     </div>

--- a/src/resources/resourceList/ResourceList.js
+++ b/src/resources/resourceList/ResourceList.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { Button, Input, Table, Tooltip } from 'antd';
 import { withRouter, useLocation, useHistory, useParams } from 'react-router-dom';
 import { InsertRowRightOutlined } from '@ant-design/icons';
-import { getColumnSearchProps } from '../../services/TableUtils';
+import { getColumnSearchProps, ResizableTitle } from '../../services/TableUtils';
 import ListHeader from './ListHeader';
 import { getNamespaced, filterResource, resourceNotifyEvent } from '../common/ResourceUtils';
 import { renderResourceList } from './ResourceListRenderer';
@@ -126,11 +126,8 @@ function ResourceList(props) {
         columns.push({
           dataIndex: column.columnTitle,
           key: column.columnContent,
-          width: '10em',
-          ellipsis: true,
-          fixed: (index === 0 ? 'left' : false),
           ...getColumnSearchProps(column.columnTitle, (text, record, dataIndex) =>
-            renderResourceList(text, record, dataIndex, resourceList)
+            renderResourceList(text, record, dataIndex, resourceList), setColumnHeaders
           ),
           title: (
             editColumn === column.columnContent ? (
@@ -182,7 +179,7 @@ function ResourceList(props) {
           ellipsis: true,
           fixed: 'left',
           ...getColumnSearchProps('Name', (text, record, dataIndex) =>
-            renderResourceList(text, record, dataIndex, resourceList)
+            renderResourceList(text, record, dataIndex, resourceList), setColumnHeaders
           ),
         },
         {
@@ -205,9 +202,8 @@ function ResourceList(props) {
               </span>
             </div>
           ),
-          ellipsis: true,
           ...getColumnSearchProps('Namespace', (text, record, dataIndex) =>
-            renderResourceList(text, record, dataIndex, resourceList)
+            renderResourceList(text, record, dataIndex, resourceList), setColumnHeaders
           ),
         }
       )
@@ -402,7 +398,12 @@ function ResourceList(props) {
       ) : null}
       <Table columns={columnHeaders} dataSource={columnContents}
              size={props.onRef ? 'small' : 'default'}
-             bordered scroll={{ x: 'max-content' }} sticky
+             components={{
+               header: {
+                 cell: ResizableTitle
+               }
+             }}
+             scroll={{ x: 'max-content' }} sticky
              pagination={{ position: ['bottomCenter'],
                hideOnSinglePage: columnContents.length < 11,
                showSizeChanger: true,


### PR DESCRIPTION
## Description
This PR adds the possibility to manage the column width of tables in the dashboard.
The modifications are NOT saved after the user leave the page, so with a refresh of the page the column widths will return to the default ones, but it is nonetheless a useful feature for various cases. 