### PR TITLE
Add new resource from CSV file

### DIFF
--- a/src/common/NamespaceSelect.js
+++ b/src/common/NamespaceSelect.js
@@ -3,7 +3,7 @@ import  { Col, Row, Select } from 'antd';
 import React, { useEffect, useRef, useState } from 'react';
 import Utils from '../services/Utils';
 
-export default function NamespaceSelect(){
+export default function NamespaceSelect(props){
   const [selectedNS, setSelectedNS] = useState('');
   const NSOptions = useRef([]);
   const NSs = useRef([]);
@@ -24,13 +24,16 @@ export default function NamespaceSelect(){
         <Select.Option key={NS.metadata.name} value={NS.metadata.name} children={NS.metadata.name}/>
       ));
 
-      NSOptions.current.push(
-        <Select.Option key={'all namespaces'} value={'all namespaces'} children={'all namespaces'}/>
-      )
+      if(props.defaultNS){
+        setSelectedNS(props.defaultNS);
+      } else {
+        NSOptions.current.push(
+          <Select.Option key={'all namespaces'} value={'all namespaces'} children={'all namespaces'}/>
+        )
 
-      handleExternalChangeNS();
-
-      window.api.NSArrayCallback.current.push(handleExternalChangeNS);
+        handleExternalChangeNS();
+        window.api.NSArrayCallback.current.push(handleExternalChangeNS);
+      }
     }).catch(error => console.log(error));
   }, [])
 
@@ -41,14 +44,17 @@ export default function NamespaceSelect(){
   }
 
   const handleChangeNS = item => {
-    window.api.setNamespace(item);
     setSelectedNS(item);
+
+    if(props.handleChangeNS)
+      props.handleChangeNS(item);
+    else window.api.setNamespace(item);
   };
 
   return(
     <Select
-      style={{paddingRight: 20, minWidth: '10em'}}
-      bordered={false}
+      style={props.style ? props.style : {paddingRight: 20, minWidth: '10em'}}
+      bordered={!!props.bordered}
       showSearch
       aria-label={'select-namespace'}
       placeholder={'Select namespace'}

--- a/src/editors/CRD/NewFromFile.js
+++ b/src/editors/CRD/NewFromFile.js
@@ -1,0 +1,218 @@
+import { Button, message, Row, Col, Table, Tooltip, Upload, Badge } from 'antd';
+import {
+  CheckOutlined,
+  CloseOutlined,
+  InboxOutlined,
+  LoadingOutlined,
+  QuestionCircleOutlined,
+  UploadOutlined
+} from '@ant-design/icons';
+import React, { useEffect, useRef, useState } from 'react';
+import Utils from '../../services/Utils';
+import _ from 'lodash';
+import { getColumnSearchProps } from '../../services/TableUtils';
+import { getNamespaced } from '../../resources/common/ResourceUtils';
+import NamespaceSelect from '../../common/NamespaceSelect';
+
+export default function NewFromFile(props){
+  const [fileContent, setFileContent] = useState([]);
+  const [columnHeaders, setColumnHeaders] = useState([]);
+  const [selectedContent, setSelectedContent] = useState([]);
+  const [namespaced, setNamespaced] = useState(false);
+  const [namespace, setNamespace] = useState('default');
+
+  useEffect(() => {
+    getNamespaced(props.genericResource.metadata.selfLink)
+      .then(res => setNamespaced(res));
+  }, []);
+
+  useEffect(() => {
+
+    setColumnHeaders([{
+      dataIndex: 'uploaded',
+      key: 'uploaded',
+      align: 'center',
+      fixed: true,
+      title: <InboxOutlined />,
+      render: (text) => {
+        if(text){
+          if(text === 1)
+            return (
+              <Tooltip title={'Uploading'} >
+                <LoadingOutlined />
+              </Tooltip>
+            )
+          else if(text === 2)
+            return (
+              <Tooltip title={'Uploaded'} >
+                <CheckOutlined />
+              </Tooltip>
+            )
+          else if(text === 3)
+            return (
+              <Tooltip title={'Not Uploaded'} >
+                <CloseOutlined />
+              </Tooltip>
+            )
+        } else return (
+          <Tooltip title={'Ready to be uploaded'} >
+            <UploadOutlined />
+          </Tooltip>
+        )
+      }
+    }]);
+    _.keys(fileContent[0]).forEach(key => {
+      if(key !== 'key' && key !== 'uploaded')
+        setColumnHeaders(prev => {
+          prev.push(
+            {
+              dataIndex: key,
+              key: key,
+              title: <div style={{marginLeft: '2em'}}>{key}</div>,
+              ...getColumnSearchProps(key, (text) =>
+                <div>{text}</div>
+              ),
+            },
+          )
+          return [...prev];
+        })
+    })
+  }, [fileContent])
+
+  const submitResource = (item, name) => {
+    let resource = {
+      apiVersion: props.genericResource.apiVersion,
+      kind: props.kind,
+      metadata: {
+        name: name,
+      },
+      spec: item
+    }
+
+    if(namespaced){
+      resource.metadata.namespace = namespace;
+    }
+
+    setFileContent(prev => {
+      prev.find(item => item.key === name).uploaded = 1;
+      return [...prev]
+    })
+
+    props.addFunction(resource)
+      .then(res => {
+        setFileContent(prev => {
+          prev.find(item => item.key === name).uploaded = 2;
+          return [...prev]
+        })
+      })
+      .catch(() => {
+        setFileContent(prev => {
+          prev.find(item => item.key === name).uploaded = 3;
+          return [...prev]
+        })
+        message.error('Could not create the resource');
+      });
+  }
+
+  const customRequest = info => {
+    const name = _.lowerCase(props.kind) + '-' + info.file.uid.split('-')[2];
+    const reader = new FileReader();
+    reader.onload = e => {
+      Utils().csvToJson(e.target.result).then(res => {
+        let counter = 0;
+
+        res.forEach(item => {
+          item.key = name + '-' + counter;
+          counter++;
+        })
+
+        /**
+         * The json file can be customized before the submit.
+         * To change the name assigned to each resource, change the item.key parameter.
+         */
+        if(window.customCSVParser)
+          res = window.customCSVParser(res);
+
+        setFileContent([...fileContent, ...res]);
+      });
+    }
+    reader.readAsText(info.file);
+  }
+
+  const uploadFile = () => {
+    let content;
+
+    if(selectedContent.length > 0)
+      content = selectedContent;
+    else content = fileContent;
+
+    content.forEach(item => {
+      submitResource(item, item.key);
+    })
+  }
+
+  const uploadProps = {
+    multiple: true,
+    showUploadList: false
+  }
+
+  const rowSelection = {
+    onChange: (selectedRowKeys, selectedRows) => {
+      setSelectedContent(selectedRows);
+    }
+  };
+
+  return(
+    <div>
+      <Upload.Dragger name={'file_'}
+                      style={{marginBottom: 20}}
+                      customRequest={customRequest}
+                      {...uploadProps}
+      >
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p className="ant-upload-text">Click or drag file to this area to upload</p>
+      </Upload.Dragger>
+      {namespaced ? (
+        <Row align={'middle'} gutter={[20, 20]}>
+          <Col>
+            <Tooltip placement="top" title={'Field required'}>
+              <Badge color={'red'}/>
+            </Tooltip>
+            Namespace
+            <Tooltip placement="top" title={'Select the namespace for the resources'}>
+              <QuestionCircleOutlined style={{ marginLeft: 5 }}/>
+            </Tooltip>
+          </Col>
+          <Col>
+            <NamespaceSelect bordered
+                             defaultNS={'default'}
+                             style={{width: '100%'}}
+                             handleChangeNS={(item) => {
+                               setNamespace(item)
+                             }}
+            />
+          </Col>
+        </Row>
+      ) : null}
+      <Table columns={columnHeaders}
+             rowSelection={{
+               type: 'checkbox',
+               ...rowSelection,
+             }}
+             dataSource={fileContent} size={'small'}
+             bordered scroll={{ x: 'max-content' }} sticky
+             pagination={{ position: ['bottomCenter'],
+               hideOnSinglePage: fileContent.length < 11,
+               showSizeChanger: true,
+             }} showSorterTooltip={false}
+      />
+      <Button style={{marginTop: 20}} block icon={<UploadOutlined />} type={'primary'}
+              onClick={uploadFile}
+      >
+        {'Import ' + (selectedContent.length === 0 ? 'All' : 'Selected') }
+      </Button>
+    </div>
+  )
+}

--- a/src/editors/CRD/NewResource.js
+++ b/src/editors/CRD/NewResource.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Tabs, message, Badge, Drawer } from 'antd';
 import FormGenerator from '../OAPIV3FormGenerator/FormGenerator';
 import Editor from '../Editor';
+import NewFromFile from './NewFromFile';
 
 function NewResource(props) {
 
@@ -24,7 +25,6 @@ function NewResource(props) {
     }
 
     if(props.resource){
-      /** A new cr from a crd */
 
       if (props.resource.spec.scope === 'Namespaced' && !namespace) {
         namespace = 'default';
@@ -73,6 +73,9 @@ function NewResource(props) {
             <FormGenerator CRD={props.resource} submit={submit}/>
           </Tabs.TabPane>
         ) : null}
+        <Tabs.TabPane tab="Import File" key="3">
+          <NewFromFile {...props} />
+        </Tabs.TabPane>
       </Tabs>
     </Drawer>
   );

--- a/src/services/Utils.js
+++ b/src/services/Utils.js
@@ -216,6 +216,11 @@ export default function Utils() {
     });
   }
 
+  function csvToJson(file) {
+    const csv = require('csvtojson');
+    return csv().fromString(file);
+  }
+
   return {
     setRealProperties,
     OAPIV3toJSONSchema,
@@ -227,6 +232,7 @@ export default function Utils() {
     parseJWT,
     setCookie,
     getCookie,
-    removeCookie
+    removeCookie,
+    csvToJson
   }
 }


### PR DESCRIPTION
## Description
With this PR is now possible to import a series of resources of the same kind from a CSV file, using the same method of creating a new resource (from the editor or the form wizard if available) and going to the `Import File` tab.
- This new method allows to create more resources of the same kind at once.
- The CSV file needs to contain the values of the `spec` of the resource.
- The names of the resources created are generated using the kind of the resource followed by a random number to guarantee the uniqueness of the resource.
- If the resource is namespaced, a namespace can be selected **for all the resources imported** (default namespace is `default`).
- If the CSV file contains more than one resource, a subset of the resources can be selected to be imported. The resources not selected will not be imported.
- If no resource is selected, the default behavior is to import them all.

![image](https://user-images.githubusercontent.com/38859529/104159454-9fe7f480-53ef-11eb-82c3-de6718c24537.png)
