### PR TITLE
Fix form reset when creating resource

### DIFF
--- a/src/editors/OAPIV3FormGenerator/FormGenerator.js
+++ b/src/editors/OAPIV3FormGenerator/FormGenerator.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import Utils from '../../services/Utils';
 import { withTheme } from '@rjsf/core';
 import { Theme as AntDTheme } from '@rjsf/antd';
@@ -12,7 +12,14 @@ const Form = withTheme(AntDTheme);
 function FormGenerator(props) {
   const util = Utils();
   let schema = util.OAPIV3toJSONSchema(props.CRD.spec.validation.openAPIV3Schema).properties.spec;
-  let currentMetadata = {};
+  let [currentMetadata, setCurrentMetadata] = useState(() => {
+    let formData = { name: '' }
+    if(props.CRD.spec.scope !== 'Cluster'){
+      formData.namespace = 'default'
+    }
+    return formData;
+  });
+  let [currentSpec, setCurrentSpec] = useState(() => props.onUpdate ? props.CR.spec : null);
 
   const onSubmit = value => {
 
@@ -36,10 +43,6 @@ function FormGenerator(props) {
     }
   }
 
-  let formData = {
-    name: ''
-  }
-
   let metadata = {
     type: 'object',
     properties: {
@@ -55,7 +58,6 @@ function FormGenerator(props) {
       type: 'string',
       description: 'The namespace of the resource. A namespace is a DNS compatible label that objects are subdivided into. The default namespace is \'default\'. '
     };
-    formData.namespace = 'default';
   }
 
   return(
@@ -66,12 +68,12 @@ function FormGenerator(props) {
               style={{marginBottom: 10}}
         >
           <Form
-            formData={formData}
+            formData={currentMetadata}
             schema={metadata}
             fields={fields}
             FieldTemplate={CustomFieldTemplate}
             widgets={widgets}
-            onChange={(value) => {currentMetadata = value.formData}}
+            onChange={(value) => {setCurrentMetadata(value.formData)}}
           >
             <div/>
           </Form>
@@ -79,11 +81,12 @@ function FormGenerator(props) {
       ) : null}
       <Form
         schema={schema}
-        formData={props.onUpdate ? props.CR.spec : null}
+        formData={currentSpec}
         fields={fields}
         FieldTemplate={CustomFieldTemplate}
         widgets={widgets}
         onSubmit={onSubmit}
+        onChange={(value) => {setCurrentSpec(value.formData)}}
       >
         <Button type="primary" htmlType={'submit'} style={{marginTop: 10}}>Submit</Button>
       </Form>

--- a/src/services/Utils.js
+++ b/src/services/Utils.js
@@ -53,8 +53,10 @@ export default function Utils() {
   }
 
   /**
-   * The field 'format' is not accepted in the Json schema,
-   * so we get rid of it before converting
+   * The field 'format' is not accepted in the Json schema
+   * so we get rid of it before converting,
+   * Change the anyOf and oneOf type to default string,
+   * Add to boolean the field 'default = false' if there is no default value
    * @param schema
    */
   const formatSchema = schema => {
@@ -63,6 +65,8 @@ export default function Utils() {
         if(schema[key].type){
           if(schema[key].type === 'object' || schema[key].type === 'array'){
             formatSchema(schema[key]);
+          } else if (schema[key].type === 'boolean' && !schema[key].default) {
+            schema[key].default = false;
           } else {
             if(schema[key].format){
               delete schema[key].format;

--- a/test/NewResource.test.js
+++ b/test/NewResource.test.js
@@ -59,9 +59,6 @@ async function check_new_CR(){
 
   userEvent.click(items[0]);
 
-  expect(await screen.findAllByText('Cost')).toHaveLength(2);
-  expect(screen.getAllByText('Name')).toHaveLength(3);
-
   const textboxes = await screen.findAllByRole('textbox');
   expect(textboxes[0]).toHaveAttribute('value', '1');
   expect(textboxes[1]).toHaveAttribute('value', 'cyan');


### PR DESCRIPTION
## Description
This PR fixes a bug that would reset the form wizard of a creating resource when another resource showed in the view is updated or added (or a corresponding watch triggered/closed/restarted).