### PR TITLE
Add customizable app title and favicon

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,6 +7,9 @@ window.OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET:-undefined}";
 window.OIDC_REDIRECT_URI="${OIDC_REDIRECT_URI:-undefined}";
 EOF
 
-sed -i".old" 's/<body>/<body><script type="text\/javascript" src="\/config.js"><\/script>/' /usr/share/nginx/html/index.html
+sed -i".old" 's#<body>#<body><script type="text/javascript" src="/config.js"></script>#' /usr/share/nginx/html/index.html
+
+[ ! -z ${APP_TITLE} ] && sed -i".old" 's#<head>#<head><title>'${APP_TITLE}'</title>#' /usr/share/nginx/html/index.html
+[ ! -z ${APP_FAVICON} ] && sed -i".old" 's#<head>#<head><link rel="icon" href="'${APP_FAVICON}'">#' /usr/share/nginx/html/index.html
 
 nginx -g "daemon off;"

--- a/kubernetes/dashboard_chart/templates/liqodash_deployment.yaml
+++ b/kubernetes/dashboard_chart/templates/liqodash_deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: liqo-dashboard-configmap
   namespace: {{ .Release.Namespace }}
 data:
+  app_favicon: ""
+  app_title: ""
   oidc_client_id: ""
   oidc_provider_url: ""
   oidc_client_secret: ""
@@ -93,6 +95,16 @@ spec:
             runAsGroup: 101
             runAsUser: 101
           env:
+            - name: APP_FAVICON
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: app_favicon
+            - name: APP_TITLE
+              valueFrom:
+                configMapKeyRef:
+                  name: liqo-dashboard-configmap
+                  key: app_title      
             - name: OIDC_PROVIDER_URL
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Description
With this PR it is possible to change the title and favicon of the application (the title and the icon that is seen in the browser tab), changing it in the dashboard configmap (named: `liqo-dashboard-configmap` in the namespace of installation, parameters `app_favicon` and `app_title`).
When the configmap is edited, to see the changes applied in the dashboard a restart of the deployment is needed, for example if the dashboard is installed in the namespace `liqo`, to restart the deployment we need the command:
```
kubectl rollout restart deployment liqo-dashboard -n liqo
```