### PR TITLE
Schema autocomplete searchbar options grouped by path

### DIFF
--- a/src/resources/common/KubernetesSchemaAutocomplete.js
+++ b/src/resources/common/KubernetesSchemaAutocomplete.js
@@ -50,6 +50,16 @@ export default function KubernetesSchemaAutocomplete(props){
     );
   }
 
+  const groupItems = tot => {
+    let temp = _.chain(tot).groupBy('label').map((value, key) => ({label: key, value:key + '.', options: value})).value();
+    temp.forEach(item => {
+      let ops = [];
+      item.options.forEach(op => ops.push(...op.options))
+      item.options = ops;
+    })
+    setTotItems(temp);
+  }
+
   const fillItems = (obj, path, counter) => {
     for (let key in obj) {
       // skip loop if the property is from prototype
@@ -75,7 +85,7 @@ export default function KubernetesSchemaAutocomplete(props){
     }
 
     if(path === '') {
-      setTotItems(tot);
+      groupItems(tot);
     }
   }
 


### PR DESCRIPTION
## Description
In this PR: the options of the dropdown menu that shows the possible parameters of a resource that can be displayed (e.g. when searching for a parameter in the resource view or selecting a parameter to add in a new column in the table showing a list of resources) are now grouped by path to help the user have a better understanding of their resources and reduce verbosity (and overall confusion).

