### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,6 @@ EOF
 sed -i".old" 's#<body>#<body><script type="text/javascript" src="/config.js"></script>#' /usr/share/nginx/html/index.html
 
 [ ! -z ${APP_TITLE} ] && sed -i".old" 's#<head>#<head><title>'${APP_TITLE}'</title>#' /usr/share/nginx/html/index.html
-[ ! -z ${APP_FAVICON} ] && sed -i".old" 's#<head>#<head><link rel="icon" href="'${APP_FAVICON}'">#' /usr/share/nginx/html/index.html
+[ ! -z ${APP_FAVICON} ] && sed -E -i".old" 's#<link rel="icon" href="(.*?)">#<link rel="icon" href="'${APP_FAVICON}'">#' /usr/share/nginx/html/index.html
 
 nginx -g "daemon off;"


### PR DESCRIPTION
## Description
Fixed `sed` operation in the `docker-entrypoint` script to substitute the favicon link tag instead of simply adding another on top.